### PR TITLE
Improve docs and repo structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,37 @@
 
 ## 🏆 Benchmark & Leaderboard
 
-* **Prompt Dimensions**: Strategy, People, Communications, Risk & Ethics
-* **Metrics**: Weighted rubric scores
-* **Run an Eval**: triggers question generation → response generation → automated grading → leaderboard update
+- **Prompt Dimensions**: Strategy, People, Communications, Risk & Ethics
+- **Metrics**: Weighted rubric scores
+- **Run an Eval**: triggers question generation → response generation → automated grading → leaderboard update
 
 ## 🚀 Landing Page
 
-A Next.js front-end displaying the leaderboard and explaining the project.
+A Next.js front-end displays the leaderboard and explains the project.
 
-**Setup & Run**
+### Setup & Run Frontend
 
 ```bash
 npm install
 npm run dev
 ```
 
+### Python Workflow
+
+The benchmark generation and grading scripts live in `./scripts`. They use the OpenAI API to create questions, produce model answers and grade them. Results are written to `./answers`, `./results` and aggregated into `./leaderboard`.
+
+## Repo Layout
+
+See `dev/CONTEXT.md` for details. Key directories are:
+
+- `prompts/` – prompt templates and rubrics
+- `questions/` – generated question YAML files
+- `scripts/` – Python automation scripts
+- `answers/` – model answers
+- `results/` – grading outputs
+- `leaderboard/` – processed leaderboard data
+- `dev/` – development notes
+
 **Deploy**
+
 Deployed on Vercel; push to `main` to update.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,7 @@ TODO: everything not already marked DONE below
 * DONE pick about 5-10 topics and a some subtopics each (./dev/topic-ideas.md has early draft)
 * DONE topics structured in dev/topics.yaml for easy iteration
 * DONE compile sample prompts and rubrics.
+* DONE created repo skeleton (prompts/, scripts/, etc) for future work
 * manually test a tiny vs big LLM on a few prompts.
 * tweak scoring
 * estimate human performance on these tasks.

--- a/answers/README.md
+++ b/answers/README.md
@@ -1,0 +1,3 @@
+# Model Answers
+
+Raw outputs from each model run are stored here, grouped by model name and question id.

--- a/dev/CONTEXT.md
+++ b/dev/CONTEXT.md
@@ -6,10 +6,11 @@ Scripts are Python. Use OpenAI chat completion API for question generation and g
 
 ## dirs in project root
 
-./prompts contains YAML files with prompt templates and rubrics.
-./scripts contains Python scripts for generation, evaluation, grading, etc
-./questions contains generated questions YAML
-./dev contains development notes and WIP stuff
-./answers contains model responses to prompts.
-./results contains evaluation results
-./leaderboard data.
+./prompts - YAML prompt templates and rubrics
+./scripts - Python scripts for generation, evaluation, grading
+./questions - generated question YAML files
+./dev - development notes and WIP docs
+./answers - model responses to prompts
+./results - evaluation results
+./leaderboard - compiled leaderboard data for the web app
+

--- a/leaderboard/README.md
+++ b/leaderboard/README.md
@@ -1,0 +1,3 @@
+# Leaderboard Data
+
+Processed metrics for display on the website live here (CSV or JSON). Update these files with the output from `results/`.

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,0 +1,3 @@
+# Prompt Templates
+
+Store YAML prompt templates and rubrics here. See `dev/topics.yaml` for topic ideas.

--- a/results/README.md
+++ b/results/README.md
@@ -1,0 +1,3 @@
+# Evaluation Results
+
+Store grading results produced by scripts in this directory. These files are later processed into `../leaderboard` data.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,8 @@
+# Python Scripts
+
+This folder contains the automation code for the benchmark.
+
+- `generate_questions.py` – load `dev/topics.yaml` and create question YAML files
+- `grade_answers.py` – grade model answers using the OpenAI API
+
+Additional scripts can be added here as the project grows.

--- a/scripts/generate_questions.py
+++ b/scripts/generate_questions.py
@@ -1,0 +1,27 @@
+"""Generate CEO Bench questions from topic list.
+
+Usage:
+    python generate_questions.py
+"""
+
+import yaml
+from pathlib import Path
+
+TOPICS_FILE = Path("dev/topics.yaml")
+OUTPUT_DIR = Path("questions")
+
+
+def main():
+    if not TOPICS_FILE.exists():
+        raise SystemExit(f"Missing {TOPICS_FILE}")
+
+    data = yaml.safe_load(TOPICS_FILE.read_text())
+    for topic in data.get("topics", []):
+        for subtopic in topic.get("subtopics", []):
+            # Placeholder logic
+            print(f"Would generate questions for {topic['name']} - {subtopic}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/grade_answers.py
+++ b/scripts/grade_answers.py
@@ -1,0 +1,19 @@
+"""Grade model answers with the OpenAI API.
+
+This is a placeholder script that would load answers and output graded results.
+"""
+
+import json
+from pathlib import Path
+
+ANSWERS_DIR = Path("answers")
+RESULTS_DIR = Path("results")
+
+
+def main():
+    print("Placeholder grading script - integrate OpenAI API calls here")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- document Python workflow and repo layout
- clarify directory structure in `dev/CONTEXT.md`
- note repo skeleton in `ROADMAP.md`
- add placeholder directories with READMEs
- stub Python scripts for question generation and grading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68532b9004d4832b9d904034e824cba8