### PR TITLE
Fix template substitution and add tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyYAML
+pytest

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+# Package for CEO Bench scripts

--- a/scripts/make_grading_prompt.py
+++ b/scripts/make_grading_prompt.py
@@ -7,7 +7,6 @@ Usage:
 import argparse
 from pathlib import Path
 import yaml
-from string import Template
 
 DEFAULT_TEMPLATE = Path("prompts/grading_prompt.txt")
 
@@ -28,8 +27,8 @@ def build_prompt(question_file: Path, answer_file: Path, template_file: Path) ->
 
     answer_text = answer_file.read_text().strip()
 
-    tmpl = Template(template_file.read_text())
-    return tmpl.safe_substitute(question=question_text, answer=answer_text, rubric=rubric_text)
+    tmpl = template_file.read_text()
+    return tmpl.format(question=question_text, answer=answer_text, rubric=rubric_text)
 
 
 def main() -> None:

--- a/scripts/make_question_prompt.py
+++ b/scripts/make_question_prompt.py
@@ -7,7 +7,7 @@ Usage:
 import argparse
 from pathlib import Path
 import yaml
-from string import Template
+
 
 DEFAULT_TEMPLATE = Path("prompts/question_prompt.txt")
 
@@ -15,8 +15,8 @@ DEFAULT_TEMPLATE = Path("prompts/question_prompt.txt")
 def build_prompt(question_file: Path, template_file: Path) -> str:
     data = yaml.safe_load(question_file.read_text())
     question_text = data.get("question", "").strip()
-    tmpl = Template(template_file.read_text())
-    return tmpl.safe_substitute(question=question_text)
+    tmpl = template_file.read_text()
+    return tmpl.format(question=question_text)
 
 
 def main() -> None:

--- a/tests/test_make_question_prompt.py
+++ b/tests/test_make_question_prompt.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.make_question_prompt import build_prompt
+
+
+def test_build_prompt_substitutes_question():
+    qfile = Path('questions/0001-Strategic_Thinking-Market_entry_strategies-European_Expansion.yaml')
+    template = Path('prompts/question_prompt.txt')
+    result = build_prompt(qfile, template)
+    assert '{question}' not in result
+    # ensure the question text from YAML appears in output
+    assert 'You are the CEO' in result
+
+
+def test_build_prompt_missing_file():
+    with pytest.raises(FileNotFoundError):
+        build_prompt(Path('questions/path-to-missing-file-should-error'), Path('prompts/question_prompt.txt'))
+


### PR DESCRIPTION
## Summary
- fix variable substitution in scripts using `str.format`
- add basic package requirements
- enable importing scripts as a package
- add regression tests for the prompt builder

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement PyYAML)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6853b4bd5600832ba9ed8bc410d0577a