### PR TITLE
Implement real question generation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,7 @@ TODO: everything not already marked DONE below
 
 ### Phase 2.5 scaling up question generation
 
-* create real questions using the /data/topics.yaml file and getting the LLM to generate them (expand generate_questions.py and refactor). this should loop through each topic and subtopic and ask the LLM to generate a question and rubric (just the first subtopic for now). we need to ensure questions are diverse in each subtopic - we can give the LLM the titles of any exisiting questions in the subtopic and ask it to be diverse. will need a new prompt template. we'll need to get this right with just 1 subtopic first, generating 10 questions. the script shold use the next available incremental ID for the question file name.
+* DONE create real questions using the /data/topics.yaml file and getting the LLM to generate them (expand generate_questions.py and refactor). this should loop through each topic and subtopic and ask the LLM to generate a question and rubric (just the first subtopic for now). we need to ensure questions are diverse in each subtopic - we can give the LLM the titles of any exisiting questions in the subtopic and ask it to be diverse. will need a new prompt template. we'll need to get this right with just 1 subtopic first, generating 10 questions. the script shold use the next available incremental ID for the question file name.
 * manually review the generated questions and rubrics
 * continue for all subtopics, then all topics
 * Filtering: remove duplicates, low-quality via heuristics.

--- a/data/questions/0004-Strategic_Thinking-Market_entry_strategies-Evaluating_Market_Selection_Criteria.yaml
+++ b/data/questions/0004-Strategic_Thinking-Market_entry_strategies-Evaluating_Market_Selection_Criteria.yaml
@@ -1,0 +1,18 @@
+topic: Strategic Thinking
+subtopic: Market entry strategies
+title: Evaluating Market Selection Criteria
+question: 'When considering entering a new international market, what key criteria
+  should be prioritized to ensure alignment with our company''s strategic goals, and
+  why?
+
+  '
+rubric:
+- dimension: Market Analysis
+  ideal: Identifies critical market factors such as size, growth potential, competitive
+    landscape, and regulatory environment.
+- dimension: Strategic Alignment
+  ideal: Aligns market choice with the company's strengths, capabilities, and long-term
+    vision.
+- dimension: Risk Assessment
+  ideal: Considers political, economic, and cultural risks and proposes mitigation
+    strategies.

--- a/data/questions/0005-Strategic_Thinking-Market_entry_strategies-Assessing_Competitive_Barriers_in_New_Markets.yaml
+++ b/data/questions/0005-Strategic_Thinking-Market_entry_strategies-Assessing_Competitive_Barriers_in_New_Markets.yaml
@@ -1,0 +1,18 @@
+topic: Strategic Thinking
+subtopic: Market entry strategies
+title: Assessing Competitive Barriers in New Markets
+question: 'How would you evaluate the competitive barriers and regulatory challenges
+  when considering entry into a new international market, and what strategies would
+  you implement to overcome them?
+
+  '
+rubric:
+- dimension: Analytical skills
+  ideal: Demonstrates ability to identify and assess key competitive and regulatory
+    hurdles in target markets with in-depth analysis.
+- dimension: Strategic planning
+  ideal: Proposes clear, actionable strategies to mitigate risks and capitalize on
+    opportunities in complex market environments.
+- dimension: Risk management
+  ideal: Effectively balances potential risks against expected benefits and outlines
+    contingency plans to ensure successful market entry.

--- a/data/questions/0006-Strategic_Thinking-Market_entry_strategies-Analyzing_Risk_Factors_for_Market_Entry.yaml
+++ b/data/questions/0006-Strategic_Thinking-Market_entry_strategies-Analyzing_Risk_Factors_for_Market_Entry.yaml
@@ -1,0 +1,17 @@
+topic: Strategic Thinking
+subtopic: Market entry strategies
+title: Analyzing Risk Factors for Market Entry
+question: 'What are the primary risks associated with entering a new international
+  market, and how would you prioritize mitigating these risks?
+
+  '
+rubric:
+- dimension: Risk Identification
+  ideal: Thoroughly identifies financial, regulatory, cultural, and operational risks
+    relevant to new markets.
+- dimension: Prioritization
+  ideal: Demonstrates ability to prioritize risks based on impact and likelihood,
+    focusing on highest threats first.
+- dimension: Mitigation Strategies
+  ideal: Proposes practical and effective strategies to reduce or manage the identified
+    risks.

--- a/data/questions/0007-Strategic_Thinking-Market_entry_strategies-Prioritizing_Market_Entry_Timing.yaml
+++ b/data/questions/0007-Strategic_Thinking-Market_entry_strategies-Prioritizing_Market_Entry_Timing.yaml
@@ -1,0 +1,17 @@
+topic: Strategic Thinking
+subtopic: Market entry strategies
+title: Prioritizing Market Entry Timing
+question: 'How would you determine the optimal timing for entering a new market to
+  maximize competitive advantage and long-term growth?
+
+  '
+rubric:
+- dimension: Market Analysis
+  ideal: Candidate demonstrates the ability to analyze market trends, growth potential,
+    and competitor activity to identify favorable entry timing.
+- dimension: Strategic Agility
+  ideal: Candidate shows flexibility in adjusting entry plans based on external factors
+    like regulation changes, economic shifts, or competitor moves.
+- dimension: Risk Management
+  ideal: Candidate balances urgency with caution, managing risks related to premature
+    or delayed entry to optimize outcomes.

--- a/data/questions/0008-Strategic_Thinking-Market_entry_strategies-Crafting_a_Differentiated_Market_Entry_Approach.yaml
+++ b/data/questions/0008-Strategic_Thinking-Market_entry_strategies-Crafting_a_Differentiated_Market_Entry_Approach.yaml
@@ -1,0 +1,17 @@
+topic: Strategic Thinking
+subtopic: Market entry strategies
+title: Crafting a Differentiated Market Entry Approach
+question: 'How would you design a market entry strategy that clearly differentiates
+  your company from existing competitors while addressing local customer needs?
+
+  '
+rubric:
+- dimension: Differentiation strategy
+  ideal: Presents a clear approach to create competitive advantage through unique
+    value propositions tailored to the target market.
+- dimension: Market understanding
+  ideal: Demonstrates in-depth knowledge of local customer preferences and adapts
+    strategy accordingly.
+- dimension: Implementation feasibility
+  ideal: Outlines practical steps ensuring the strategy can be executed effectively
+    with measurable milestones.

--- a/data/questions/0009-Strategic_Thinking-Market_entry_strategies-Designing_Partnerships_for_Market_Entry.yaml
+++ b/data/questions/0009-Strategic_Thinking-Market_entry_strategies-Designing_Partnerships_for_Market_Entry.yaml
@@ -1,0 +1,17 @@
+topic: Strategic Thinking
+subtopic: Market entry strategies
+title: Designing Partnerships for Market Entry
+question: 'How would you evaluate and select strategic partnerships to facilitate
+  successful entry into a new international market?
+
+  '
+rubric:
+- dimension: Partnership selection criteria
+  ideal: Candidate explains how to assess alignment in goals, capabilities, reputation,
+    and local market knowledge when choosing partners.
+- dimension: Risk and benefit analysis
+  ideal: Candidate weighs potential risks such as dependency or misalignment against
+    benefits like local access, resource sharing, and credibility.
+- dimension: Integration and collaboration strategy
+  ideal: Candidate outlines a clear plan to establish effective communication, shared
+    objectives, and conflict resolution mechanisms with partners.

--- a/data/questions/0010-Strategic_Thinking-Market_entry_strategies-Identifying_Key_Market_Entry_Partners.yaml
+++ b/data/questions/0010-Strategic_Thinking-Market_entry_strategies-Identifying_Key_Market_Entry_Partners.yaml
@@ -1,0 +1,17 @@
+topic: Strategic Thinking
+subtopic: Market entry strategies
+title: Identifying Key Market Entry Partners
+question: 'How would you identify and evaluate potential partners that can facilitate
+  a successful market entry in a new region?
+
+  '
+rubric:
+- dimension: Partner relevance
+  ideal: Demonstrates ability to assess partner alignment with company values, market
+    knowledge, and resources
+- dimension: Strategic fit
+  ideal: Explains how the partner complements company capabilities and helps overcome
+    entry barriers
+- dimension: Risk management
+  ideal: Considers risks related to partner reliability, conflicts of interest, and
+    regulatory compliance

--- a/data/questions/0011-Strategic_Thinking-Market_entry_strategies-Tailoring_Market_Entry_Models_to_Local_Dynamics.yaml
+++ b/data/questions/0011-Strategic_Thinking-Market_entry_strategies-Tailoring_Market_Entry_Models_to_Local_Dynamics.yaml
@@ -1,0 +1,17 @@
+topic: Strategic Thinking
+subtopic: Market entry strategies
+title: Tailoring Market Entry Models to Local Dynamics
+question: 'How would you adapt your market entry model to address unique cultural,
+  regulatory, and economic factors in a new target market?
+
+  '
+rubric:
+- dimension: Cultural Adaptation
+  ideal: Demonstrates understanding of local customs and consumer behavior to customize
+    offerings and marketing.
+- dimension: Regulatory Compliance
+  ideal: Identifies key legal and regulatory requirements and integrates them into
+    the entry strategy effectively.
+- dimension: Economic Context
+  ideal: Considers economic environment such as purchasing power and market size to
+    optimize investment and growth approach.

--- a/data/questions/0012-Strategic_Thinking-Market_entry_strategies-Integrating_Digital_Channels_in_Market_Entry.yaml
+++ b/data/questions/0012-Strategic_Thinking-Market_entry_strategies-Integrating_Digital_Channels_in_Market_Entry.yaml
@@ -1,0 +1,17 @@
+topic: Strategic Thinking
+subtopic: Market entry strategies
+title: Integrating Digital Channels in Market Entry
+question: 'How would you leverage digital channels to enhance market entry success
+  in a new region while considering local customer behavior and existing competition?
+
+  '
+rubric:
+- dimension: Digital Strategy Integration
+  ideal: Describes a clear approach to incorporating digital channels such as e-commerce,
+    social media, and digital marketing tailored to local preferences and infrastructure.
+- dimension: Competitive Analysis
+  ideal: Demonstrates understanding of local digital competition and outlines tactics
+    to gain advantage or differentiation through digital means.
+- dimension: Customer-Centric Adaptation
+  ideal: Shows awareness of local customer behavior and preferences, highlighting
+    adaptation of digital engagement strategies to meet their needs effectively.

--- a/data/questions/0013-Strategic_Thinking-Market_entry_strategies-Optimizing_Resource_Allocation_for_Market_Entry.yaml
+++ b/data/questions/0013-Strategic_Thinking-Market_entry_strategies-Optimizing_Resource_Allocation_for_Market_Entry.yaml
@@ -1,0 +1,17 @@
+topic: Strategic Thinking
+subtopic: Market entry strategies
+title: Optimizing Resource Allocation for Market Entry
+question: 'How would you prioritize and allocate resources effectively to maximize
+  impact during the initial stages of entering a new market?
+
+  '
+rubric:
+- dimension: Resource prioritization
+  ideal: Demonstrates ability to identify critical activities and allocate budget,
+    talent, and time accordingly to ensure swift and effective market penetration.
+- dimension: Strategic alignment
+  ideal: Aligns resource allocation with overall business goals and market entry objectives,
+    ensuring coherence across teams and initiatives.
+- dimension: Risk mitigation
+  ideal: Incorporates contingency planning and flexible resource deployment to handle
+    unforeseen challenges or shifts in market conditions.

--- a/dev/CONTEXT.md
+++ b/dev/CONTEXT.md
@@ -2,7 +2,9 @@
 
 Front end is Next.js.
 
-Scripts are Python. Use OpenAI chat completion API for question generation and grading. Offline helpers like `generate_questions.py` and `aggregate_results.py` assist with creating data without API calls.
+Scripts are Python. Use the `llm` CLI for question generation, answer generation and grading.
+`generate_questions.py` now calls the API using `templates/question_gen_prompt.txt`
+to create YAML question files. `aggregate_results.py` compiles scoring data.
 
 ## dirs in project root
 

--- a/scripts/generate_questions.py
+++ b/scripts/generate_questions.py
@@ -1,19 +1,25 @@
-"""Generate CEO Bench question YAML files from topics list.
+"""Generate CEO Bench question YAML files.
 
-This offline version creates placeholder questions for development.
+This script can produce simple placeholder questions or use the ``llm`` CLI to
+create real questions with rubrics.  Topics are read from ``data/topics.yaml``.
 
-Usage:
-    python generate_questions.py
+Usage::
+
+    python generate_questions.py [--model gpt-4.1-mini]
 """
 
+import argparse
+import subprocess
 import yaml
 from pathlib import Path
 import re
 
 DATA_DIR = Path("data")
 
-TOPICS_FILE = Path("dev/topics.yaml")
+TOPICS_FILE = DATA_DIR / "topics.yaml"
 OUTPUT_DIR = DATA_DIR / "questions"
+TEMPLATES_DIR = Path("templates")
+DEFAULT_TEMPLATE = TEMPLATES_DIR / "question_gen_prompt.txt"
 
 ID_RE = re.compile(r"^(\d+)-")
 
@@ -27,11 +33,12 @@ def next_id() -> int:
     return max_id + 1
 
 
-def build_filename(qid: int, topic: str, subtopic: str) -> Path:
+def build_filename(qid: int, topic: str, subtopic: str, title: str) -> Path:
+    """Return a safe path for a new question file."""
     safe_topic = topic.replace(" ", "_")
     safe_sub = subtopic.replace(" ", "_")
-    title = subtopic.replace(" ", "_")
-    name = f"{qid:04d}-{safe_topic}-{safe_sub}-{title}.yaml"
+    safe_title = title.replace(" ", "_")
+    name = f"{qid:04d}-{safe_topic}-{safe_sub}-{safe_title}.yaml"
     return OUTPUT_DIR / name
 
 
@@ -49,24 +56,87 @@ def create_question(topic: str, subtopic: str) -> dict:
     }
 
 
-def main():
+def existing_titles(topic: str, subtopic: str) -> list[str]:
+    """Return a list of question titles already generated for this subtopic."""
+    titles = []
+    safe_topic = topic.replace(" ", "_")
+    safe_sub = subtopic.replace(" ", "_")
+    pattern = f"*-{safe_topic}-{safe_sub}-*.yaml"
+    for path in OUTPUT_DIR.glob(pattern):
+        try:
+            data = yaml.safe_load(path.read_text())
+        except Exception:
+            continue
+        if isinstance(data, dict) and data.get("title"):
+            titles.append(str(data["title"]))
+    return titles
+
+
+def build_prompt(topic: str, subtopic: str, titles: list[str], template_file: Path) -> str:
+    tmpl = template_file.read_text()
+    joined = "\n".join(f"- {t}" for t in titles) if titles else "none"
+    return tmpl.format(topic=topic, subtopic=subtopic, existing_titles=joined)
+
+
+def call_llm(prompt: str, model: str) -> str:
+    result = subprocess.run([
+        "llm",
+        "prompt",
+        "-m",
+        model,
+        prompt,
+    ], capture_output=True, text=True, check=True)
+    return result.stdout.strip()
+
+
+def extract_yaml(text: str) -> str:
+    """Return YAML block from llm output."""
+    if "```" in text:
+        parts = text.split("```")
+        if len(parts) >= 3:
+            # assume yaml block is the part between first and last fences
+            block = "".join(parts[1:-1]).strip()
+            if block.startswith("yaml\n"):
+                block = block[5:]
+            return block
+    return text.strip()
+
+
+def create_question_llm(topic: str, subtopic: str, titles: list[str], model: str, template_file: Path) -> dict:
+    prompt = build_prompt(topic, subtopic, titles, template_file)
+    text = call_llm(prompt, model)
+    return yaml.safe_load(extract_yaml(text))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate questions")
+    parser.add_argument("--model", default="gpt-4.1-mini", help="Model name")
+    parser.add_argument("--count", type=int, default=10, help="Questions to generate")
+    parser.add_argument("--template", type=Path, default=DEFAULT_TEMPLATE, help="Prompt template")
+    args = parser.parse_args()
+
     if not TOPICS_FILE.exists():
         raise SystemExit(f"Missing {TOPICS_FILE}")
 
     OUTPUT_DIR.mkdir(exist_ok=True)
 
     data = yaml.safe_load(TOPICS_FILE.read_text())
+    topic = data.get("topics", [])[0]
+    subtopic = topic.get("subtopics", [])[0]
+
     qid = next_id()
-    for topic in data.get("topics", []):
-        for subtopic in topic.get("subtopics", []):
-            outfile = build_filename(qid, topic["name"], subtopic)
-            if outfile.exists():
-                qid += 1
-                continue
-            qdata = create_question(topic["name"], subtopic)
-            outfile.write_text(yaml.safe_dump(qdata, sort_keys=False))
-            print(f"Wrote {outfile}")
-            qid += 1
+    for _ in range(args.count):
+        titles = existing_titles(topic["name"], subtopic)
+        qdata = create_question_llm(topic["name"], subtopic, titles, args.model, args.template)
+        outfile = build_filename(
+            qid,
+            qdata.get("topic", topic["name"]),
+            qdata.get("subtopic", subtopic),
+            qdata.get("title", str(qid)),
+        )
+        outfile.write_text(yaml.safe_dump(qdata, sort_keys=False))
+        print(f"Wrote {outfile}")
+        qid += 1
 
 
 if __name__ == "__main__":

--- a/templates/question_gen_prompt.txt
+++ b/templates/question_gen_prompt.txt
@@ -1,0 +1,22 @@
+You are generating new questions for the CEO Bench evaluation.
+Each question should focus on the given topic and subtopic.
+Avoid repeating any of the existing titles listed below.
+Return YAML in the following structure:
+
+```
+topic: {topic}
+subtopic: {subtopic}
+title: <short title>
+question: |
+  <one to two sentence question>
+rubric:
+  - dimension: <dimension 1>
+    ideal: <ideal answer description>
+  - dimension: <dimension 2>
+    ideal: <ideal answer description>
+  - dimension: <dimension 3>
+    ideal: <ideal answer description>
+```
+
+Existing titles:
+{existing_titles}

--- a/tests/test_generate_questions.py
+++ b/tests/test_generate_questions.py
@@ -7,7 +7,7 @@ from scripts.generate_questions import build_filename, create_question
 
 
 def test_build_filename_structure():
-    path = build_filename(1, "Strategic Thinking", "Market Entry")
+    path = build_filename(1, "Strategic Thinking", "Market Entry", "Market Entry")
     assert path == Path("data/questions/0001-Strategic_Thinking-Market_Entry-Market_Entry.yaml")
 
 


### PR DESCRIPTION
## Summary
- fix `build_filename` to include title and sanitize file names
- add helper to strip code blocks from llm output
- update tests for new function signature
- generate first batch of real questions for the Market entry strategies subtopic

## Testing
- `pytest -q`
- `python scripts/generate_questions.py --count 9`

------
https://chatgpt.com/codex/tasks/task_e_685491bb9df4832b8672a2cf1a5961ac