### PR TITLE
Move context info to README

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,4 +5,4 @@ See /README.md for more details.
 
 See /ROADMAP.md for the implementation roadmap.
 
-See /dev/CONTEXT.md for context and directory structure.
+See /README.md for context and directory structure.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Use the /dev directory for development notes and WIP stuff.
 
 See /ROADMAP.md for the implementation roadmap. Prefix items with DONE as you work on them.
 
-See /dev/CONTEXT.md for context and directory structure.
+See /README.md for context and directory structure.
 
 That's it! Good luck!
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,32 @@ npm run dev
 
 Deployed on Vercel; push to `main` to update.
 
+## Project Structure
+
+The front end is a **Next.js** application. Python scripts power question
+generation, answer generation and grading using the `llm` CLI.  Key files:
+
+- `generate_questions.py` uses `templates/question_gen_prompt.txt` to create
+  YAML question files.
+- `aggregate_results.py` compiles scoring data into the leaderboard.
+
+Important directories:
+
+- `templates/` – prompt templates and rubrics
+- `scripts/` – Python scripts for generation, evaluation and grading
+  - `generate_answers.py` calls `llm` to produce an answer for a question
+  - `grade_answers.py` grades an answer with `llm` using a JSON schema so
+    results include parsed scores
+- `data/questions/` – generated question YAML files
+- `data/answers/` – model responses to prompts
+- `data/results/` – evaluation results
+- `data/leaderboard/` – compiled leaderboard data for the web app
+- `dev/` – development notes and WIP docs
+
 
 ### Evaluation Workflow (Python)
 
-```p
-bash
+```bash
 pip install -r requirements.txt
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 ## CEO Bench Implementation Roadmap
 
-(this file should be edited as progress is made. also update /dev/CONTEXT.md with anything useful for future developers)
+(this file should be edited as progress is made. see README for project context and directory structure)
 
 TODO: everything not already marked DONE below
 


### PR DESCRIPTION
## Summary
- integrate dev/CONTEXT content into README under a new **Project Structure** section
- update links in AGENTS, ROADMAP and copilot instructions to reference README
- fix README code block formatting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685668daf984832bb5d885f650200b16