### PR TITLE
Add grading model option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Important directories:
 - `templates/` – prompt templates and rubrics
 - `scripts/` – Python scripts for generation, evaluation and grading
   - `generate_answers.py` calls `llm` to produce an answer for a question
-  - `grade_answers.py` grades an answer with `llm` using a JSON schema so
+  - `grade_answer.py` grades an answer with `llm` using a JSON schema so
     results include parsed scores
 - `data/questions/` – generated question YAML files
 - `data/answers/` – model responses to prompts
@@ -65,7 +65,7 @@ This isa done in 2 parts:
 
 `generate_answers.py` uses the `llm` CLI to fetch a model answer and stores it under `data/answers/<model>/`.
 
-`grade_answers.py` runs the grading prompt with `llm` using a JSON schema so the scores are parsed and written to `data/results`.
+`grade_answer.py` runs the grading prompt with `llm` using a JSON schema so the scores are parsed and written to `data/results`.
 
 #### Running the full pipeline
 
@@ -76,7 +76,8 @@ updates the leaderboard.
 Example:
 
 ```bash
-python scripts/run_full_evals.py --models gpt-4.1-nano gpt-4.1-mini
+python scripts/run_full_evals.py --models gpt-4.1-nano gpt-4.1-mini \
+    --grading-model gpt-4.1-mini
 ```
 
 Use `--rerun-answer` or `--rerun-grade` to force regeneration.

--- a/dev/CONTEXT.md
+++ b/dev/CONTEXT.md
@@ -11,7 +11,7 @@ to create YAML question files. `aggregate_results.py` compiles scoring data.
 ./templates - prompt templates and rubrics
 ./scripts - Python scripts for generation, evaluation, grading
     - generate_answers.py calls `llm` to produce an answer for a question
-    - grade_answers.py grades an answer using `llm` with a JSON schema so results include parsed scores
+    - grade_answer.py grades an answer using `llm` with a JSON schema so results include parsed scores
 ./data/questions - generated question YAML files
 ./dev - development notes and WIP docs (should be empty when the project is complete)
 ./data/answers - model responses to prompts

--- a/scripts/grade_answer.py
+++ b/scripts/grade_answer.py
@@ -1,7 +1,8 @@
 """Grade an answer using llm and store JSON results.
 
 Usage:
-    python grade_answers.py question.yaml answer.txt --model gpt-4.1-mini
+    python grade_answer.py question.yaml answer.txt \
+        --model MODEL_NAME [--grading-model gpt-4.1-mini]
 """
 
 import argparse
@@ -41,7 +42,12 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Grade an answer using llm")
     parser.add_argument("question", type=Path, help="Question YAML file")
     parser.add_argument("answer", type=Path, help="Answer text file")
-    parser.add_argument("--model", default="gpt-4.1-mini", help="Model name")
+    parser.add_argument("--model", required=True, help="Model being evaluated")
+    parser.add_argument(
+        "--grading-model",
+        default="gpt-4.1-mini",
+        help="Model used to grade the answer",
+    )
     args = parser.parse_args()
 
     qdata = yaml.safe_load(args.question.read_text())
@@ -49,7 +55,7 @@ def main() -> None:
 
     prompt = build_prompt(args.question, args.answer, DEFAULT_TEMPLATE)
     schema = build_schema(dimensions)
-    grading_text = call_llm(prompt, args.model, schema)
+    grading_text = call_llm(prompt, args.grading_model, schema)
 
     try:
         parsed = json.loads(grading_text)

--- a/scripts/run_full_evals.py
+++ b/scripts/run_full_evals.py
@@ -39,6 +39,11 @@ def main() -> None:
         action="store_true",
         help="Regenerate grading even if results already exist",
     )
+    parser.add_argument(
+        "--grading-model",
+        default="gpt-4.1-mini",
+        help="Model used for grading",
+    )
     args = parser.parse_args()
 
     questions = sorted(QUESTIONS_DIR.glob("*.yaml"))
@@ -63,11 +68,13 @@ def main() -> None:
             if args.rerun_grade or not result_path.exists():
                 run([
                     sys.executable,
-                    str(SCRIPTS_DIR / "grade_answers.py"),
+                    str(SCRIPTS_DIR / "grade_answer.py"),
                     str(qfile),
                     str(answer_path),
                     "--model",
                     model,
+                    "--grading-model",
+                    args.grading_model,
                 ])
             else:
                 print(f"Skipping grading for {qfile.stem} ({model})")


### PR DESCRIPTION
## Summary
- rename `grade_answers.py` to `grade_answer.py`
- allow choosing a grading model in `run_full_evals.py`
- support `--grading-model` option in `grade_answer.py`
- document the new option and renamed script in README and dev notes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68566c4d1074832ba8e8c401854c6745