### PR TITLE
Add model name mapping

### DIFF
--- a/data/leaderboard/leaderboard.csv
+++ b/data/leaderboard/leaderboard.csv
@@ -1,4 +1,4 @@
-model,overall,n,Strategic Thinking,Operational Excellence,Leadership & Communication,Financial Acumen,Risk & Ethics,Innovation & Growth
-gpt-4.1-nano,115.975,125,114.176,118.005,115.788,117.869,115.506,117.269
-gpt-4.1-mini,121.464,125,122.222,120.08,119.941,120.25,122.759,122.581
-gpt-4.1,120.0,1,120.0,,,,,
+model,model_name,overall,n,Strategic Thinking,Operational Excellence,Leadership & Communication,Financial Acumen,Risk & Ethics,Innovation & Growth
+gpt-4.1-nano,Open AI GPT-4.1 Nano,115.975,125,114.176,118.005,115.788,117.869,115.506,117.269
+gpt-4.1-mini,Open AI GPT-4.1 Mini,121.464,125,122.222,120.08,119.941,120.25,122.759,122.581
+gpt-4.1,Open AI GPT-4.1,120.0,1,120.0,,,,,

--- a/data/model_names.yaml
+++ b/data/model_names.yaml
@@ -1,0 +1,20 @@
+model_names:
+  gpt-4o: Open AI GPT-4o
+  chatgpt-4o-latest: Open AI ChatGPT 4o Latest
+  gpt-4o-mini: Open AI GPT-4o Mini
+  gpt-4.1: Open AI GPT-4.1
+  gpt-4.1-mini: Open AI GPT-4.1 Mini
+  gpt-4.1-nano: Open AI GPT-4.1 Nano
+  gpt-3.5-turbo: Open AI GPT-3.5 Turbo
+  gpt-3.5-turbo-16k: Open AI GPT-3.5 Turbo 16K
+  gpt-4: Open AI GPT-4
+  gpt-4-32k: Open AI GPT-4 32K
+  gpt-4-turbo: Open AI GPT-4 Turbo
+  gpt-4.5-preview: Open AI GPT-4.5 Preview
+  o1: Open AI O1
+  o1-preview: Open AI O1 Preview
+  o1-mini: Open AI O1 Mini
+  o3-mini: Open AI O3 Mini
+  o3: Open AI O3
+  o4-mini: Open AI O4 Mini
+  gpt-3.5-turbo-instruct: Open AI GPT-3.5 Turbo Instruct

--- a/tests/test_aggregate_results.py
+++ b/tests/test_aggregate_results.py
@@ -12,7 +12,7 @@ def test_aggregate_computes_averages():
         {"model": "A", "total": 5.0, "topic": "Y"},
         {"model": "B", "total": 2.0, "topic": "X"},
     ]
-    rows = aggregate(records, ["X", "Y"])
+    rows = aggregate(records, ["X", "Y"], {"A": "Model A", "B": "Model B"})
     data = {row["model"]: row for row in rows}
     assert data["A"]["overall"] == 4.5
     assert data["A"]["n"] == 2
@@ -20,3 +20,10 @@ def test_aggregate_computes_averages():
     assert data["A"]["Y"] == 5.0
     assert data["B"]["overall"] == 2.0
     assert data["B"]["n"] == 1
+    assert data["A"]["model_name"] == "Model A"
+
+
+def test_model_name_fallback():
+    records = [{"model": "X", "total": 3.0, "topic": "T"}]
+    rows = aggregate(records, ["T"], {})
+    assert rows[0]["model_name"] == "X"


### PR DESCRIPTION
## Summary
- map model IDs to friendly names in `data/model_names.yaml`
- read this mapping in `aggregate_results.py` and write a `model_name` column
- test new behaviour and update leaderboard data

## Testing
- `pytest -q`
- `python scripts/aggregate_results.py`

------
https://chatgpt.com/codex/tasks/task_e_6856881a8a80832b9bc1b5958340ef58