### PR TITLE
Shorten leaderboard column labels

### DIFF
--- a/components/Leaderboard.tsx
+++ b/components/Leaderboard.tsx
@@ -8,6 +8,15 @@ interface Row {
   [key: string]: string
 }
 
+const TOPIC_LABELS: Record<string, string> = {
+  'Strategic Thinking': 'Strategy',
+  'Operational Excellence': 'Management',
+  'Leadership & Communication': 'Communication',
+  'Financial Acumen': 'Finance',
+  'Risk & Ethics': 'Risk & Ethics',
+  'Innovation & Growth': 'Innovation',
+}
+
 async function loadCsv(): Promise<Row[]> {
   const csvPath = path.join(process.cwd(), 'data/leaderboard/leaderboard.csv')
   const text = await fs.readFile(csvPath, 'utf8')
@@ -59,7 +68,7 @@ export default async function Leaderboard() {
                 <th className="text-center py-3 px-2 font-semibold text-slate-700">Overall</th>
                 {topics.map(topic => (
                   <th key={topic} className="text-center py-3 px-2 font-semibold text-slate-700">
-                    {topic}
+                    {TOPIC_LABELS[topic] ?? topic}
                   </th>
                 ))}
               </tr>


### PR DESCRIPTION
## Summary
- map long CSV topic names to shorter labels in `Leaderboard` component

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68568d8da02c832b89f39846f6c29f9f