### PR TITLE
Update stats from leaderboard

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,8 +4,17 @@ import { Badge } from "@/components/ui/badge"
 import { Github, FileText, Trophy, BarChart3, Users, Target, ArrowRight } from "lucide-react"
 import Link from "next/link"
 import Leaderboard from "@/components/Leaderboard"
+import { loadLeaderboard } from '@/lib/leaderboard'
 
 export default async function Component() {
+  const rows = await loadLeaderboard()
+  const scenarioCount = rows.reduce((m, r) => Math.max(m, Number(r.n)), 0)
+  const llmCount = rows.length
+  const topicKeys = rows[0]
+    ? Object.keys(rows[0]).filter(k => !['model', 'model_name', 'overall', 'n'].includes(k))
+    : []
+  const compCount = topicKeys.length
+  const topScore = rows.reduce((m, r) => Math.max(m, Number(r.overall)), 0)
 
   return (
     <div className="flex flex-col min-h-screen bg-white">
@@ -91,19 +100,19 @@ export default async function Component() {
           <div className="container px-4 md:px-6">
             <div className="grid grid-cols-2 md:grid-cols-4 gap-8 max-w-4xl mx-auto">
               <div className="text-center">
-                <div className="text-3xl md:text-4xl font-bold text-slate-900">500+</div>
+                <div className="text-3xl md:text-4xl font-bold text-slate-900">{scenarioCount}</div>
                 <div className="text-sm text-slate-600 mt-1">Executive Scenarios</div>
               </div>
               <div className="text-center">
-                <div className="text-3xl md:text-4xl font-bold text-slate-900">12</div>
+                <div className="text-3xl md:text-4xl font-bold text-slate-900">{llmCount}</div>
                 <div className="text-sm text-slate-600 mt-1">Leading LLMs Tested</div>
               </div>
               <div className="text-center">
-                <div className="text-3xl md:text-4xl font-bold text-slate-900">4</div>
+                <div className="text-3xl md:text-4xl font-bold text-slate-900">{compCount}</div>
                 <div className="text-sm text-slate-600 mt-1">Core Competencies</div>
               </div>
               <div className="text-center">
-                <div className="text-3xl md:text-4xl font-bold text-slate-900">TBC</div>
+                <div className="text-3xl md:text-4xl font-bold text-slate-900">{topScore.toFixed(1)}</div>
                 <div className="text-sm text-slate-600 mt-1">Top Model Score</div>
               </div>
             </div>

--- a/components/Leaderboard.tsx
+++ b/components/Leaderboard.tsx
@@ -1,12 +1,7 @@
-import fs from 'fs/promises'
-import path from 'path'
+import { loadLeaderboard } from '@/lib/leaderboard'
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { BarChart3, Trophy } from "lucide-react"
-
-interface Row {
-  [key: string]: string
-}
 
 const TOPIC_LABELS: Record<string, string> = {
   'Strategic Thinking': 'Strategy',
@@ -17,20 +12,6 @@ const TOPIC_LABELS: Record<string, string> = {
   'Innovation & Growth': 'Innovation',
 }
 
-async function loadCsv(): Promise<Row[]> {
-  const csvPath = path.join(process.cwd(), 'data/leaderboard/leaderboard.csv')
-  const text = await fs.readFile(csvPath, 'utf8')
-  const lines = text.trim().split(/\r?\n/)
-  const headers = lines[0].split(',').map(h => h.trim())
-  return lines.slice(1).map(line => {
-    const values = line.split(',').map(v => v.trim())
-    const row: Row = {}
-    headers.forEach((h, i) => {
-      row[h] = values[i] ?? ''
-    })
-    return row
-  })
-}
 
 function format(val?: string) {
   if (!val) return '–'
@@ -39,7 +20,7 @@ function format(val?: string) {
 }
 
 export default async function Leaderboard() {
-  const rows = await loadCsv()
+  const rows = await loadLeaderboard()
   const topics = rows[0]
     ? Object.keys(rows[0]).filter(
         k => !['model', 'model_name', 'overall', 'n'].includes(k)

--- a/lib/leaderboard.ts
+++ b/lib/leaderboard.ts
@@ -1,0 +1,21 @@
+import fs from 'fs/promises'
+import path from 'path'
+
+export interface Row {
+  [key: string]: string
+}
+
+export async function loadLeaderboard(): Promise<Row[]> {
+  const csvPath = path.join(process.cwd(), 'data/leaderboard/leaderboard.csv')
+  const text = await fs.readFile(csvPath, 'utf8')
+  const lines = text.trim().split(/\r?\n/)
+  const headers = lines[0].split(',').map(h => h.trim())
+  return lines.slice(1).map(line => {
+    const values = line.split(',').map(v => v.trim())
+    const row: Row = {}
+    headers.forEach((h, i) => {
+      row[h] = values[i] ?? ''
+    })
+    return row
+  })
+}


### PR DESCRIPTION
## Summary
- share CSV loader between components
- use leaderboard data for hero stats
- drop unused `Row` type after refactor

## Testing
- `npm install`
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6856907d1478832babb9e2de24dcf031