### PR TITLE
Add leaderboard bar chart

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,7 +45,8 @@ TODO: everything not already marked DONE below
 
 * DONE write script to turn results into leaderboard data
 * DONE make leaderboard display in Next.js app, updating on deploy
-* make fancy charts (bar chart and IQ curve), including human baseline range
+* DONE add bar chart with human baseline to leaderboard page
+* make fancy charts (IQ curve), including human baseline range
 
 ### phase 5 Analysis / evaluation of findings / interpretation
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge"
 import { Github, FileText, Trophy, BarChart3, Users, Target, ArrowRight } from "lucide-react"
 import Link from "next/link"
 import Leaderboard from "@/components/Leaderboard"
+import ModelsBarChart from "@/components/ModelsBarChart"
 import { loadLeaderboard } from '@/lib/leaderboard'
 
 export default async function Component() {
@@ -129,6 +130,10 @@ export default async function Component() {
                   Rankings based on comprehensive evaluation across strategic thinking, operational excellence,
                   leadership capabilities, and financial acumen.
                 </p>
+              </div>
+
+              <div className="mb-8">
+                <ModelsBarChart rows={rows} />
               </div>
 
               <Leaderboard />

--- a/components/ModelsBarChart.tsx
+++ b/components/ModelsBarChart.tsx
@@ -4,28 +4,14 @@ import { Row } from '@/lib/leaderboard'
 import { Chart } from 'react-chartjs-2'
 import {
   Chart as ChartJS,
-  BarElement,
-  CategoryScale,
-  LinearScale,
-  PointElement,
-  LineElement,
-  Tooltip,
-  Legend,
+  registerables,
   type ScriptableContext,
   type ChartDataset,
   type ChartData,
   type ChartOptions,
 } from 'chart.js'
 
-ChartJS.register(
-  CategoryScale,
-  LinearScale,
-  BarElement,
-  PointElement,
-  LineElement,
-  Tooltip,
-  Legend
-)
+ChartJS.register(...registerables)
 
 interface Props {
   rows: Row[]

--- a/components/ModelsBarChart.tsx
+++ b/components/ModelsBarChart.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { Row } from '@/lib/leaderboard'
+import { Bar } from 'react-chartjs-2'
+import {
+  Chart as ChartJS,
+  BarElement,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+  type ScriptableContext,
+} from 'chart.js'
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend
+)
+
+interface Props {
+  rows: Row[]
+}
+
+export default function ModelsBarChart({ rows }: Props) {
+  if (!rows.length) return null
+  const topics = Object.keys(rows[0]).filter(k => !['model','model_name','overall','n'].includes(k))
+  const labels = ['Overall', ...topics]
+
+  const datasets = rows.map((row, idx) => ({
+    label: row.model_name || row.model,
+    data: [Number(row.overall), ...topics.map(t => Number(row[t]))],
+    backgroundColor: `var(--color-chart-${(idx % 5) + 1})`,
+    borderColor: 'black',
+    borderWidth: (ctx: ScriptableContext<'bar'>) =>
+      ctx.dataIndex === 0 ? 2 : 0,
+  }))
+
+  datasets.push({
+    label: 'Human CEO',
+    type: 'line' as const,
+    data: new Array(labels.length).fill(100),
+    borderColor: '#888',
+    borderDash: [4,4],
+    borderWidth: 2,
+    pointRadius: 0,
+  })
+
+  const data = { labels, datasets }
+
+  const options = {
+    responsive: true,
+    interaction: { mode: 'index' as const, intersect: false },
+    stacked: false,
+    plugins: {
+      legend: { position: 'top' as const },
+    },
+    scales: {
+      y: { beginAtZero: true },
+    },
+  }
+
+  return <Bar data={data} options={options} />
+}
+

--- a/components/ModelsBarChart.tsx
+++ b/components/ModelsBarChart.tsx
@@ -12,6 +12,7 @@ import {
   Tooltip,
   Legend,
   type ScriptableContext,
+  type ChartDataset,
 } from 'chart.js'
 
 ChartJS.register(
@@ -33,24 +34,26 @@ export default function ModelsBarChart({ rows }: Props) {
   const topics = Object.keys(rows[0]).filter(k => !['model','model_name','overall','n'].includes(k))
   const labels = ['Overall', ...topics]
 
-  const datasets = rows.map((row, idx) => ({
-    label: row.model_name || row.model,
-    data: [Number(row.overall), ...topics.map(t => Number(row[t]))],
-    backgroundColor: `var(--color-chart-${(idx % 5) + 1})`,
-    borderColor: 'black',
-    borderWidth: (ctx: ScriptableContext<'bar'>) =>
-      ctx.dataIndex === 0 ? 2 : 0,
-  }))
+  const datasets: ChartDataset<'bar' | 'line', number[]>[] = rows.map(
+    (row, idx) => ({
+      label: row.model_name || row.model,
+      data: [Number(row.overall), ...topics.map(t => Number(row[t]))],
+      backgroundColor: `var(--color-chart-${(idx % 5) + 1})`,
+      borderColor: 'black',
+      borderWidth: (ctx: ScriptableContext<'bar'>) =>
+        ctx.dataIndex === 0 ? 2 : 0,
+    })
+  )
 
   datasets.push({
     label: 'Human CEO',
-    type: 'line' as const,
+    type: 'line',
     data: new Array(labels.length).fill(100),
     borderColor: '#888',
-    borderDash: [4,4],
+    borderDash: [4, 4],
     borderWidth: 2,
     pointRadius: 0,
-  })
+  } as ChartDataset<'line', number[]>)
 
   const data = { labels, datasets }
 

--- a/components/ModelsBarChart.tsx
+++ b/components/ModelsBarChart.tsx
@@ -63,7 +63,6 @@ export default function ModelsBarChart({ rows }: Props) {
   const options: ChartOptions<'bar' | 'line'> = {
     responsive: true,
     interaction: { mode: 'index' as const, intersect: false },
-    stacked: false,
     plugins: {
       legend: { position: 'top' as const },
     },

--- a/components/ModelsBarChart.tsx
+++ b/components/ModelsBarChart.tsx
@@ -22,11 +22,13 @@ export default function ModelsBarChart({ rows }: Props) {
   const topics = Object.keys(rows[0]).filter(k => !['model','model_name','overall','n'].includes(k))
   const labels = ['Overall', ...topics]
 
+  const colors = ['#4dc9f6', '#f67019', '#f53794', '#537bc4', '#acc236']
+
   const datasets: ChartDataset<'bar' | 'line', number[]>[] = rows.map((row, idx) => {
     const dataset: ChartDataset<'bar', number[]> = {
       label: row.model_name || row.model,
       data: [Number(row.overall), ...topics.map(t => Number(row[t]))],
-      backgroundColor: `var(--color-chart-${(idx % 5) + 1})`,
+      backgroundColor: colors[idx % colors.length],
       borderColor: 'black',
       borderWidth: (ctx: ScriptableContext<'bar'>) =>
         ctx.dataIndex === 0 ? 2 : 0,

--- a/components/ModelsBarChart.tsx
+++ b/components/ModelsBarChart.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Row } from '@/lib/leaderboard'
-import { Bar } from 'react-chartjs-2'
+import { Chart } from 'react-chartjs-2'
 import {
   Chart as ChartJS,
   BarElement,
@@ -13,6 +13,8 @@ import {
   Legend,
   type ScriptableContext,
   type ChartDataset,
+  type ChartData,
+  type ChartOptions,
 } from 'chart.js'
 
 ChartJS.register(
@@ -34,16 +36,17 @@ export default function ModelsBarChart({ rows }: Props) {
   const topics = Object.keys(rows[0]).filter(k => !['model','model_name','overall','n'].includes(k))
   const labels = ['Overall', ...topics]
 
-  const datasets: ChartDataset<'bar' | 'line', number[]>[] = rows.map(
-    (row, idx) => ({
+  const datasets: ChartDataset<'bar' | 'line', number[]>[] = rows.map((row, idx) => {
+    const dataset: ChartDataset<'bar', number[]> = {
       label: row.model_name || row.model,
       data: [Number(row.overall), ...topics.map(t => Number(row[t]))],
       backgroundColor: `var(--color-chart-${(idx % 5) + 1})`,
       borderColor: 'black',
       borderWidth: (ctx: ScriptableContext<'bar'>) =>
         ctx.dataIndex === 0 ? 2 : 0,
-    })
-  )
+    }
+    return dataset
+  })
 
   datasets.push({
     label: 'Human CEO',
@@ -55,9 +58,9 @@ export default function ModelsBarChart({ rows }: Props) {
     pointRadius: 0,
   } as ChartDataset<'line', number[]>)
 
-  const data = { labels, datasets }
+  const data: ChartData<'bar' | 'line', number[], string> = { labels, datasets }
 
-  const options = {
+  const options: ChartOptions<'bar' | 'line'> = {
     responsive: true,
     interaction: { mode: 'index' as const, intersect: false },
     stacked: false,
@@ -69,6 +72,6 @@ export default function ModelsBarChart({ rows }: Props) {
     },
   }
 
-  return <Bar data={data} options={options} />
+  return <Chart type='bar' data={data} options={options} />
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.3",
+        "chart.js": "^4.5.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.517.0",
         "next": "15.2.4",
         "react": "^19.0.0",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0",
         "tailwind-merge": "^3.3.1"
       },
@@ -690,6 +692,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.11",
@@ -2170,6 +2178,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chownr": {
@@ -4793,6 +4813,16 @@
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",
+    "chart.js": "^4.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.517.0",
     "next": "15.2.4",
     "react": "^19.0.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.3.1"
   },


### PR DESCRIPTION
## Summary
- add a new `ModelsBarChart` component using Chart.js
- show the bar chart above the leaderboard
- record progress in the roadmap
- include chart.js dependencies

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_685692df6cc8832b982e7943e4beaefa