### PR TITLE
Handle slash characters in model names

### DIFF
--- a/scripts/generate_answers.py
+++ b/scripts/generate_answers.py
@@ -12,6 +12,8 @@ import argparse
 import subprocess
 from pathlib import Path
 
+from model_utils import encode_model_name
+
 DATA_DIR = Path("data")
 
 from make_question_prompt import build_prompt, DEFAULT_TEMPLATE
@@ -44,7 +46,8 @@ def main() -> None:
     prompt = build_prompt(args.question, DEFAULT_TEMPLATE)
     response = call_llm(prompt, args.model)
 
-    model_dir = ANSWERS_DIR / args.model
+    safe_model = encode_model_name(args.model)
+    model_dir = ANSWERS_DIR / safe_model
     model_dir.mkdir(parents=True, exist_ok=True)
     outfile = model_dir / (args.question.stem + ".txt")
     outfile.write_text(response)

--- a/scripts/grade_answer.py
+++ b/scripts/grade_answer.py
@@ -11,6 +11,8 @@ import subprocess
 from pathlib import Path
 import yaml
 
+from model_utils import encode_model_name
+
 DATA_DIR = Path("data")
 
 from make_grading_prompt import build_prompt, DEFAULT_TEMPLATE
@@ -65,7 +67,8 @@ def main() -> None:
         parsed = None
 
     RESULTS_DIR.mkdir(exist_ok=True)
-    outfile = RESULTS_DIR / f"{args.answer.stem}-{args.model}.json"
+    safe_model = encode_model_name(args.model)
+    outfile = RESULTS_DIR / f"{args.answer.stem}-{safe_model}.json"
     record = {
         "question_id": args.question.stem,
         "model": args.model,

--- a/scripts/model_utils.py
+++ b/scripts/model_utils.py
@@ -1,0 +1,11 @@
+from urllib.parse import quote, unquote
+
+
+def encode_model_name(model: str) -> str:
+    """Return a filesystem-safe version of the model name."""
+    return quote(model, safe="")
+
+
+def decode_model_name(name: str) -> str:
+    """Reverse ``encode_model_name``."""
+    return unquote(name)

--- a/scripts/run_full_evals.py
+++ b/scripts/run_full_evals.py
@@ -11,6 +11,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from model_utils import encode_model_name
+
 DATA_DIR = Path("data")
 QUESTIONS_DIR = DATA_DIR / "questions"
 ANSWERS_DIR = DATA_DIR / "answers"
@@ -49,7 +51,8 @@ def main() -> None:
     questions = sorted(QUESTIONS_DIR.glob("*.yaml"))
 
     for model in args.models:
-        model_answer_dir = ANSWERS_DIR / model
+        safe_model = encode_model_name(model)
+        model_answer_dir = ANSWERS_DIR / safe_model
         model_answer_dir.mkdir(parents=True, exist_ok=True)
         for qfile in questions:
             answer_path = model_answer_dir / f"{qfile.stem}.txt"
@@ -64,7 +67,7 @@ def main() -> None:
             else:
                 print(f"Skipping answer for {qfile.stem} ({model})")
 
-            result_path = RESULTS_DIR / f"{qfile.stem}-{model}.json"
+            result_path = RESULTS_DIR / f"{qfile.stem}-{safe_model}.json"
             if args.rerun_grade or not result_path.exists():
                 run([
                     sys.executable,

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scripts.model_utils import encode_model_name, decode_model_name
+
+
+def test_round_trip():
+    original = "groq/llama3-8b-8192"
+    encoded = encode_model_name(original)
+    assert "/" not in encoded
+    assert decode_model_name(encoded) == original


### PR DESCRIPTION
## Summary
- add encode/decode helpers for model names in filenames
- sanitize model names when generating answers and grading
- update run_full_evals.py to use sanitized model names
- test new model utils

## Testing
- `pytest -q`
- `llm prompt -m groq/llama3-8b-8192 'Hello'` *(fails: No key found)*

------
https://chatgpt.com/codex/tasks/task_e_68569cef5624832b8a2f6419c78465d7