### PR TITLE
Improve leaderboard charts

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { Github, FileText, Trophy, BarChart3, Users, Target, ArrowRight } from "
 import Link from "next/link"
 import Leaderboard from "@/components/Leaderboard"
 import ModelsBarChart from "@/components/ModelsBarChart"
+import OverallBarChart from "@/components/OverallBarChart"
 import { loadLeaderboard } from '@/lib/leaderboard'
 
 export default async function Component() {
@@ -136,10 +137,14 @@ export default async function Component() {
               </div>
 
               <div className="mb-8">
-                <ModelsBarChart rows={rows} />
+                <OverallBarChart rows={rows} />
               </div>
 
               <Leaderboard />
+
+              <div className="mt-8">
+                <ModelsBarChart rows={rows} />
+              </div>
             </div>
           </div>
         </section>

--- a/components/OverallBarChart.tsx
+++ b/components/OverallBarChart.tsx
@@ -17,21 +17,18 @@ interface Props {
   rows: Row[]
 }
 
-export default function ModelsBarChart({ rows }: Props) {
+export default function OverallBarChart({ rows }: Props) {
   if (!rows.length) return null
-  const topics = Object.keys(rows[0]).filter(k => !['model','model_name','overall','n'].includes(k))
-  const labels = ['Overall', ...topics]
-
+  const labels = ['Overall']
   const colors = ['#4dc9f6', '#f67019', '#f53794', '#537bc4', '#acc236']
 
   const datasets: ChartDataset<'bar' | 'line', number[]>[] = rows.map((row, idx) => {
     const dataset: ChartDataset<'bar', number[]> = {
       label: row.model_name || row.model,
-      data: [Number(row.overall), ...topics.map(t => Number(row[t]))],
+      data: [Number(row.overall)],
       backgroundColor: colors[idx % colors.length],
       borderColor: 'black',
-      borderWidth: (ctx: ScriptableContext<'bar'>) =>
-        ctx.dataIndex === 0 ? 2 : 0,
+      borderWidth: 2,
     }
     return dataset
   })
@@ -39,7 +36,7 @@ export default function ModelsBarChart({ rows }: Props) {
   datasets.push({
     label: 'Human CEO',
     type: 'line',
-    data: new Array(labels.length).fill(100),
+    data: [100],
     borderColor: '#888',
     borderDash: [4, 4],
     borderWidth: 2,
@@ -61,7 +58,7 @@ export default function ModelsBarChart({ rows }: Props) {
   }
 
   return (
-    <div className="min-h-[400px]">
+    <div className="min-h-[300px]">
       <Chart type='bar' data={data} options={options} />
     </div>
   )

--- a/components/OverallBarChart.tsx
+++ b/components/OverallBarChart.tsx
@@ -5,7 +5,6 @@ import { Chart } from 'react-chartjs-2'
 import {
   Chart as ChartJS,
   registerables,
-  type ScriptableContext,
   type ChartDataset,
   type ChartData,
   type ChartOptions,


### PR DESCRIPTION
## Summary
- add a new `OverallBarChart` to display only overall scores against the human baseline
- tweak `ModelsBarChart` to be taller and resize responsively
- update the leaderboard section to show the simple chart above the table
- keep the detailed chart below the table

## Testing
- `pytest -q`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b39ce4d0832bb1391097f107aa56