### PR TITLE
Sort bar charts by highest score

### DIFF
--- a/components/ModelsBarChart.tsx
+++ b/components/ModelsBarChart.tsx
@@ -19,12 +19,13 @@ interface Props {
 
 export default function ModelsBarChart({ rows }: Props) {
   if (!rows.length) return null
-  const topics = Object.keys(rows[0]).filter(k => !['model','model_name','overall','n'].includes(k))
+  const ordered = [...rows].sort((a, b) => Number(b.overall) - Number(a.overall))
+  const topics = Object.keys(ordered[0]).filter(k => !['model','model_name','overall','n'].includes(k))
   const labels = ['Overall', ...topics]
 
   const colors = ['#4dc9f6', '#f67019', '#f53794', '#537bc4', '#acc236']
 
-  const datasets: ChartDataset<'bar' | 'line', number[]>[] = rows.map((row, idx) => {
+  const datasets: ChartDataset<'bar' | 'line', number[]>[] = ordered.map((row, idx) => {
     const dataset: ChartDataset<'bar', number[]> = {
       label: row.model_name || row.model,
       data: [Number(row.overall), ...topics.map(t => Number(row[t]))],

--- a/components/OverallBarChart.tsx
+++ b/components/OverallBarChart.tsx
@@ -18,10 +18,11 @@ interface Props {
 
 export default function OverallBarChart({ rows }: Props) {
   if (!rows.length) return null
+  const ordered = [...rows].sort((a, b) => Number(b.overall) - Number(a.overall))
   const labels = ['Overall']
   const colors = ['#4dc9f6', '#f67019', '#f53794', '#537bc4', '#acc236']
 
-  const datasets: ChartDataset<'bar' | 'line', number[]>[] = rows.map((row, idx) => {
+  const datasets: ChartDataset<'bar' | 'line', number[]>[] = ordered.map((row, idx) => {
     const dataset: ChartDataset<'bar', number[]> = {
       label: row.model_name || row.model,
       data: [Number(row.overall)],


### PR DESCRIPTION
## Summary
- sort ModelsBarChart and OverallBarChart data by descending overall score before generating chart datasets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856b98fbcf8832bbeab73cb056ceff8