### PR TITLE
Fix overall chart human CEO bar & color palette

### DIFF
--- a/components/ModelsBarChart.tsx
+++ b/components/ModelsBarChart.tsx
@@ -23,7 +23,18 @@ export default function ModelsBarChart({ rows }: Props) {
   const topics = Object.keys(ordered[0]).filter(k => !['model','model_name','overall','n'].includes(k))
   const labels = ['Overall', ...topics]
 
-  const colors = ['#4dc9f6', '#f67019', '#f53794', '#537bc4', '#acc236']
+  const colors = [
+    '#4dc9f6',
+    '#f67019',
+    '#f53794',
+    '#537bc4',
+    '#acc236',
+    '#166a8f',
+    '#00a950',
+    '#58595b',
+    '#8549ba',
+    '#b50808',
+  ]
 
   const datasets: ChartDataset<'bar' | 'line', number[]>[] = ordered.map((row, idx) => {
     const dataset: ChartDataset<'bar', number[]> = {

--- a/components/OverallBarChart.tsx
+++ b/components/OverallBarChart.tsx
@@ -47,8 +47,8 @@ export default function OverallBarChart({ rows }: Props) {
   datasets.push({
     label: 'Human CEO',
     data: [100],
-    backgroundColor: colors[datasets.length % colors.length],
-    borderColor: 'black',
+    backgroundColor: '#888',
+    borderColor: '#888',
     borderWidth: 2,
   } as ChartDataset<'bar', number[]>)
 

--- a/components/OverallBarChart.tsx
+++ b/components/OverallBarChart.tsx
@@ -20,7 +20,18 @@ export default function OverallBarChart({ rows }: Props) {
   if (!rows.length) return null
   const ordered = [...rows].sort((a, b) => Number(b.overall) - Number(a.overall))
   const labels = ['Overall']
-  const colors = ['#4dc9f6', '#f67019', '#f53794', '#537bc4', '#acc236']
+  const colors = [
+    '#4dc9f6',
+    '#f67019',
+    '#f53794',
+    '#537bc4',
+    '#acc236',
+    '#166a8f',
+    '#00a950',
+    '#58595b',
+    '#8549ba',
+    '#b50808',
+  ]
 
   const datasets: ChartDataset<'bar' | 'line', number[]>[] = ordered.map((row, idx) => {
     const dataset: ChartDataset<'bar', number[]> = {
@@ -35,13 +46,11 @@ export default function OverallBarChart({ rows }: Props) {
 
   datasets.push({
     label: 'Human CEO',
-    type: 'line',
     data: [100],
-    borderColor: '#888',
-    borderDash: [4, 4],
+    backgroundColor: colors[datasets.length % colors.length],
+    borderColor: 'black',
     borderWidth: 2,
-    pointRadius: 0,
-  } as ChartDataset<'line', number[]>)
+  } as ChartDataset<'bar', number[]>)
 
   const data: ChartData<'bar' | 'line', number[], string> = { labels, datasets }
 


### PR DESCRIPTION
## Summary
- show Human CEO as a bar in `OverallBarChart`
- expand bar chart color palette to 10 colors

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856bc48838c832ba90180d67bfb3775