### PR TITLE
Fix Python lint

### DIFF
--- a/scripts/check_model.py
+++ b/scripts/check_model.py
@@ -17,7 +17,9 @@ def call_llm(model: str) -> str:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Send a hello prompt to a model")
+    parser = argparse.ArgumentParser(
+        description="Send a hello prompt to a model"
+    )
     parser.add_argument("--model", default="gpt-4.1-mini", help="Model name")
     args = parser.parse_args()
 

--- a/scripts/generate_answers.py
+++ b/scripts/generate_answers.py
@@ -13,10 +13,9 @@ import subprocess
 from pathlib import Path
 
 from model_utils import encode_model_name
+from make_question_prompt import build_prompt, DEFAULT_TEMPLATE
 
 DATA_DIR = Path("data")
-
-from make_question_prompt import build_prompt, DEFAULT_TEMPLATE
 
 ANSWERS_DIR = DATA_DIR / "answers"
 
@@ -38,7 +37,9 @@ def call_llm(prompt: str, model: str) -> str:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Generate an answer using llm")
+    parser = argparse.ArgumentParser(
+        description="Generate an answer using llm"
+    )
     parser.add_argument("question", type=Path, help="Question YAML file")
     parser.add_argument("--model", default="gpt-4.1-mini", help="Model name")
     args = parser.parse_args()

--- a/scripts/generate_questions.py
+++ b/scripts/generate_questions.py
@@ -9,39 +9,33 @@ Usage::
 """
 
 import argparse
-import yaml
-from pathlib import Path
-
 import sys
 from pathlib import Path
+import yaml
 
 if __package__ is None:
     sys.path.append(str(Path(__file__).resolve().parents[1]))
     from scripts.question_utils import (
-        DATA_DIR,
         TOPICS_FILE,
         OUTPUT_DIR,
         DEFAULT_TEMPLATE,
         next_id,
         build_filename,
         existing_titles,
-        create_question,
+        create_question,  # noqa: F401
         create_question_llm,
     )
 else:
     from .question_utils import (
-        DATA_DIR,
         TOPICS_FILE,
         OUTPUT_DIR,
         DEFAULT_TEMPLATE,
         next_id,
         build_filename,
         existing_titles,
-        create_question,
+        create_question,  # noqa: F401
         create_question_llm,
     )
-
-
 
 
 def main() -> None:

--- a/scripts/grade_answer.py
+++ b/scripts/grade_answer.py
@@ -12,10 +12,9 @@ from pathlib import Path
 import yaml
 
 from model_utils import encode_model_name
+from make_grading_prompt import build_prompt, DEFAULT_TEMPLATE
 
 DATA_DIR = Path("data")
-
-from make_grading_prompt import build_prompt, DEFAULT_TEMPLATE
 
 RESULTS_DIR = DATA_DIR / "results"
 

--- a/scripts/make_grading_prompt.py
+++ b/scripts/make_grading_prompt.py
@@ -1,7 +1,8 @@
 """Generate a grading prompt from a question YAML file and an answer text file.
 
 Usage:
-    python make_grading_prompt.py question.yaml answer.txt [--template templates/grading_prompt.txt]
+    python make_grading_prompt.py question.yaml answer.txt \
+        [--template templates/grading_prompt.txt]
 """
 
 import argparse
@@ -22,7 +23,9 @@ def load_rubric(data: dict) -> str:
     return "\n".join(f"- {line}" for line in rubric_lines)
 
 
-def build_prompt(question_file: Path, answer_file: Path, template_file: Path) -> str:
+def build_prompt(
+    question_file: Path, answer_file: Path, template_file: Path
+) -> str:
     qdata = yaml.safe_load(question_file.read_text())
     question_text = qdata.get("question", "").strip()
     rubric_text = load_rubric(qdata)
@@ -30,14 +33,25 @@ def build_prompt(question_file: Path, answer_file: Path, template_file: Path) ->
     answer_text = answer_file.read_text().strip()
 
     tmpl = template_file.read_text()
-    return tmpl.format(question=question_text, answer=answer_text, rubric=rubric_text)
+    return tmpl.format(
+        question=question_text,
+        answer=answer_text,
+        rubric=rubric_text,
+    )
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Create grading prompt for an LLM")
+    parser = argparse.ArgumentParser(
+        description="Create grading prompt for an LLM"
+    )
     parser.add_argument("question", type=Path, help="Question YAML file")
     parser.add_argument("answer", type=Path, help="Answer text file")
-    parser.add_argument("--template", type=Path, default=DEFAULT_TEMPLATE, help="Prompt template")
+    parser.add_argument(
+        "--template",
+        type=Path,
+        default=DEFAULT_TEMPLATE,
+        help="Prompt template",
+    )
     args = parser.parse_args()
 
     prompt = build_prompt(args.question, args.answer, args.template)

--- a/scripts/make_question_prompt.py
+++ b/scripts/make_question_prompt.py
@@ -1,7 +1,8 @@
 """Generate a text prompt from a question YAML file.
 
 Usage:
-    python make_question_prompt.py path/to/question.yaml [--template templates/question_prompt.txt]
+    python make_question_prompt.py path/to/question.yaml \
+        [--template templates/question_prompt.txt]
 """
 
 import argparse
@@ -22,9 +23,16 @@ def build_prompt(question_file: Path, template_file: Path) -> str:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Create prompt for an LLM")
+    parser = argparse.ArgumentParser(
+        description="Create prompt for an LLM"
+    )
     parser.add_argument("question", type=Path, help="Question YAML file")
-    parser.add_argument("--template", type=Path, default=DEFAULT_TEMPLATE, help="Prompt template")
+    parser.add_argument(
+        "--template",
+        type=Path,
+        default=DEFAULT_TEMPLATE,
+        help="Prompt template",
+    )
     args = parser.parse_args()
 
     prompt = build_prompt(args.question, args.template)

--- a/scripts/question_utils.py
+++ b/scripts/question_utils.py
@@ -31,15 +31,23 @@ def build_filename(qid: int, topic: str, subtopic: str, title: str) -> Path:
 
 
 def create_question(topic: str, subtopic: str) -> dict:
-    question_text = f"How would you approach the challenge of {subtopic.lower()}?"
+    question_text = (
+        f"How would you approach the challenge of {subtopic.lower()}?"
+    )
     return {
         "topic": topic,
         "subtopic": subtopic,
         "title": subtopic,
         "question": question_text,
         "rubric": [
-            {"dimension": "Clarity", "ideal": "Answer is clear and structured."},
-            {"dimension": "Insight", "ideal": "Demonstrates thoughtful reasoning."},
+            {
+                "dimension": "Clarity",
+                "ideal": "Answer is clear and structured.",
+            },
+            {
+                "dimension": "Insight",
+                "ideal": "Demonstrates thoughtful reasoning.",
+            },
         ],
     }
 
@@ -60,10 +68,16 @@ def existing_titles(topic: str, subtopic: str) -> list[str]:
     return titles
 
 
-def build_prompt(topic: str, subtopic: str, titles: list[str], template_file: Path) -> str:
+def build_prompt(
+    topic: str, subtopic: str, titles: list[str], template_file: Path
+) -> str:
     tmpl = template_file.read_text()
     joined = "\n".join(f"- {t}" for t in titles) if titles else "none"
-    return tmpl.format(topic=topic, subtopic=subtopic, existing_titles=joined)
+    return tmpl.format(
+        topic=topic,
+        subtopic=subtopic,
+        existing_titles=joined,
+    )
 
 
 def call_llm(prompt: str, model: str) -> str:
@@ -88,11 +102,20 @@ def extract_yaml(text: str) -> str:
     return text.strip()
 
 
-def create_question_llm(topic: str, subtopic: str, titles: list[str], model: str, template_file: Path) -> dict:
+def create_question_llm(
+    topic: str,
+    subtopic: str,
+    titles: list[str],
+    model: str,
+    template_file: Path,
+) -> dict:
     prompt = build_prompt(topic, subtopic, titles, template_file)
     text = call_llm(prompt, model)
     try:
         return yaml.safe_load(extract_yaml(text))
     except yaml.YAMLError:
-        print("Failed to parse YAML from llm output, falling back to placeholder question")
+        print(
+            "Failed to parse YAML from llm output, "
+            "falling back to placeholder question"
+        )
         return create_question(topic, subtopic)

--- a/scripts/regenerate_question.py
+++ b/scripts/regenerate_question.py
@@ -39,7 +39,12 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Regenerate a question")
     parser.add_argument("id", type=int, help="Question ID")
     parser.add_argument("--model", default="gpt-4.1-mini", help="Model name")
-    parser.add_argument("--template", type=Path, default=DEFAULT_TEMPLATE, help="Prompt template")
+    parser.add_argument(
+        "--template",
+        type=Path,
+        default=DEFAULT_TEMPLATE,
+        help="Prompt template",
+    )
     args = parser.parse_args()
 
     qfile = find_question_file(args.id)
@@ -51,7 +56,13 @@ def main() -> None:
     if data.get("title") in titles:
         titles.remove(data.get("title"))
 
-    new_data = create_question_llm(topic, subtopic, titles, args.model, args.template)
+    new_data = create_question_llm(
+        topic,
+        subtopic,
+        titles,
+        args.model,
+        args.template,
+    )
 
     outfile = build_filename(
         args.id,

--- a/tests/test_aggregate_results.py
+++ b/tests/test_aggregate_results.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from scripts.aggregate_results import aggregate
+from scripts.aggregate_results import aggregate  # noqa: E402
 
 
 def test_aggregate_computes_averages():

--- a/tests/test_generate_questions.py
+++ b/tests/test_generate_questions.py
@@ -3,12 +3,19 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from scripts.generate_questions import build_filename, create_question
+from scripts.generate_questions import build_filename, create_question  # noqa: E402
 
 
 def test_build_filename_structure():
-    path = build_filename(1, "Strategic Thinking", "Market Entry", "Market Entry")
-    assert path == Path("data/questions/0001-Strategic_Thinking-Market_Entry-Market_Entry.yaml")
+    path = build_filename(
+        1,
+        "Strategic Thinking",
+        "Market Entry",
+        "Market Entry",
+    )
+    assert path == Path(
+        "data/questions/0001-Strategic_Thinking-Market_Entry-Market_Entry.yaml"
+    )
 
 
 def test_create_question_contains_fields():

--- a/tests/test_make_grading_prompt.py
+++ b/tests/test_make_grading_prompt.py
@@ -3,7 +3,11 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from scripts.make_grading_prompt import load_rubric, build_prompt, DEFAULT_TEMPLATE
+from scripts.make_grading_prompt import (  # noqa: E402
+    load_rubric,
+    build_prompt,
+    DEFAULT_TEMPLATE,
+)
 
 
 def test_load_rubric_formats_lines():
@@ -19,8 +23,14 @@ def test_load_rubric_formats_lines():
 
 
 def test_build_prompt_replaces_placeholders():
-    qfile = Path('data/questions/0001-Strategic_Thinking-Market_entry_strategies-European_Expansion.yaml')
-    afile = Path('data/answers/gpt-4.1-nano/0001-Strategic_Thinking-Market_entry_strategies-European_Expansion.txt')
+    qfile = Path(
+        'data/questions/0001-Strategic_Thinking-Market_entry_strategies-Europ'
+        'ean_Expansion.yaml'
+    )
+    afile = Path(
+        'data/answers/gpt-4.1-nano/0001-Strategic_Thinking-Market_entry_strat'
+        'egies-European_Expansion.txt'
+    )
     prompt = build_prompt(qfile, afile, DEFAULT_TEMPLATE)
     assert '{question}' not in prompt
     assert '{answer}' not in prompt

--- a/tests/test_make_question_prompt.py
+++ b/tests/test_make_question_prompt.py
@@ -4,11 +4,14 @@ from pathlib import Path
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from scripts.make_question_prompt import build_prompt
+from scripts.make_question_prompt import build_prompt  # noqa: E402
 
 
 def test_build_prompt_substitutes_question():
-    qfile = Path('data/questions/0001-Strategic_Thinking-Market_entry_strategies-European_Expansion.yaml')
+    qfile = Path(
+        'data/questions/0001-Strategic_Thinking-Market_entry_strategies-Europ'
+        'ean_Expansion.yaml'
+    )
     template = Path('templates/question_prompt.txt')
     result = build_prompt(qfile, template)
     assert '{question}' not in result
@@ -18,5 +21,8 @@ def test_build_prompt_substitutes_question():
 
 def test_build_prompt_missing_file():
     with pytest.raises(FileNotFoundError):
-        build_prompt(Path('data/questions/path-to-missing-file-should-error'), Path('templates/question_prompt.txt'))
+        build_prompt(
+            Path('data/questions/path-to-missing-file-should-error'),
+            Path('templates/question_prompt.txt'),
+        )
 

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from scripts.model_utils import encode_model_name, decode_model_name
+from scripts.model_utils import encode_model_name, decode_model_name  # noqa: E402
 
 
 def test_round_trip():


### PR DESCRIPTION
## Summary
- clean up flake8 issues across scripts and tests
- keep helper functions exported from generate_questions
- adjust docs to follow 80 char lines

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856c41396c4832b894734200c6cfb8b