### PR TITLE
Fix lint issues

### DIFF
--- a/scripts/generate_questions.py
+++ b/scripts/generate_questions.py
@@ -15,25 +15,25 @@ import yaml
 
 if __package__ is None:
     sys.path.append(str(Path(__file__).resolve().parents[1]))
-    from scripts.question_utils import (
+    from scripts.question_utils import (  # noqa: F401
         TOPICS_FILE,
         OUTPUT_DIR,
         DEFAULT_TEMPLATE,
         next_id,
         build_filename,
         existing_titles,
-        create_question,  # noqa: F401
+        create_question,
         create_question_llm,
     )
 else:
-    from .question_utils import (
+    from .question_utils import (  # noqa: F401
         TOPICS_FILE,
         OUTPUT_DIR,
         DEFAULT_TEMPLATE,
         next_id,
         build_filename,
         existing_titles,
-        create_question,  # noqa: F401
+        create_question,
         create_question_llm,
     )
 

--- a/tests/test_generate_questions.py
+++ b/tests/test_generate_questions.py
@@ -3,7 +3,10 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from scripts.generate_questions import build_filename, create_question  # noqa: E402
+from scripts.generate_questions import (  # noqa: E402
+    build_filename,
+    create_question,
+)
 
 
 def test_build_filename_structure():

--- a/tests/test_make_question_prompt.py
+++ b/tests/test_make_question_prompt.py
@@ -25,4 +25,3 @@ def test_build_prompt_missing_file():
             Path('data/questions/path-to-missing-file-should-error'),
             Path('templates/question_prompt.txt'),
         )
-

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -3,7 +3,10 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from scripts.model_utils import encode_model_name, decode_model_name  # noqa: E402
+from scripts.model_utils import (  # noqa: E402
+    encode_model_name,
+    decode_model_name,
+)
 
 
 def test_round_trip():


### PR DESCRIPTION
## Summary
- ignore F401 correctly for `create_question`
- wrap imports in tests to satisfy line length
- remove trailing blank line in prompt test

## Testing
- `flake8 --exclude node_modules .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856cb115ca4832bbda564978041835b