### PR TITLE
Add colourful gradients

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -51,8 +51,9 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
+  /* brand accent colour */
+  --primary: oklch(0.55 0.25 278);
+  --primary-foreground: oklch(0.99 0 0);
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
@@ -85,8 +86,8 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
+  --primary: oklch(0.75 0.25 278);
+  --primary-foreground: oklch(0.15 0 0);
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,7 +24,7 @@ export default async function Component() {
       <header className="border-b bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/60 sticky top-0 z-50">
         <div className="container flex h-16 items-center justify-between px-4 md:px-6">
           <div className="flex items-center space-x-3">
-            <div className="flex items-center justify-center w-10 h-10 bg-slate-900 text-white rounded-lg font-bold text-lg">
+            <div className="flex items-center justify-center w-10 h-10 bg-gradient-to-br from-blue-600 via-purple-600 to-pink-600 text-white rounded-lg font-bold text-lg">
               CEO
             </div>
             <div>
@@ -65,7 +65,7 @@ export default async function Component() {
 
       <main className="flex-1">
         {/* Hero Section */}
-        <section className="py-20 md:py-32 bg-gradient-to-b from-slate-50 to-white">
+        <section className="py-20 md:py-32 bg-gradient-to-b from-blue-50 via-purple-50 to-white">
           <div className="container px-4 md:px-6">
             <div className="max-w-4xl mx-auto text-center space-y-8">
               <div className="space-y-4">
@@ -74,7 +74,7 @@ export default async function Component() {
                 </Badge>
                 <h1 className="text-4xl md:text-6xl font-bold text-slate-900 leading-tight">
                   Can AI Replace the
-                  <span className="text-slate-700"> C-Suite?</span>
+                  <span className="bg-gradient-to-r from-blue-600 via-purple-600 to-pink-600 bg-clip-text text-transparent"> C-Suite?</span>
                 </h1>
                 <p className="text-xl md:text-2xl text-slate-600 max-w-3xl mx-auto leading-relaxed">
                   CEO Bench is an open benchmark measuring how well large language models tackle
@@ -82,7 +82,7 @@ export default async function Component() {
                 </p>
               </div>
               <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
-                <Button size="lg" asChild className="bg-slate-900 hover:bg-slate-800">
+                <Button size="lg" asChild className="bg-gradient-to-r from-blue-600 via-purple-600 to-pink-600 hover:from-blue-700 hover:via-purple-700 hover:to-pink-700 text-white">
                   <Link href="#leaderboard" className="flex items-center space-x-2">
                     <Trophy className="w-5 h-5" />
                     <span>View Leaderboard</span>
@@ -289,7 +289,7 @@ export default async function Component() {
         <div className="container px-4 md:px-6">
           <div className="flex flex-col md:flex-row items-center justify-between">
             <div className="flex items-center space-x-3 mb-4 md:mb-0">
-              <div className="flex items-center justify-center w-8 h-8 bg-slate-900 text-white rounded font-bold text-sm">
+              <div className="flex items-center justify-center w-8 h-8 bg-gradient-to-br from-blue-600 via-purple-600 to-pink-600 text-white rounded font-bold text-sm">
                 CEO
               </div>
               <span className="font-semibold text-slate-900">CEO Bench</span>


### PR DESCRIPTION
## Summary
- tweak global colour palette to feature a purple accent
- add gradient logos and button to homepage
- brighten hero background and heading

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6856cd6957e8832b819ffd65771498f0