### PR TITLE
Add sampling option to eval runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
    ```bash
    python scripts/run_full_evals.py --models gpt-4.1-nano gpt-4.1-mini --grading-model gpt-4.1-mini
    ```
+   Add `--sample 0.25` to evaluate on a random subset of questions (default is `1`).
 
 You can also run the steps individually:
 

--- a/tests/test_run_full_evals.py
+++ b/tests/test_run_full_evals.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
+from scripts import run_full_evals  # noqa: E402
+
+
+def test_select_questions_sampling(tmp_path):
+    files = [tmp_path / f"{i:04d}.yaml" for i in range(10)]
+    for f in files:
+        f.touch()
+    subset = run_full_evals.select_questions(files, 0.3)
+    assert len(subset) == max(1, int(len(files) * 0.3))
+    assert all(s in files for s in subset)
+
+
+def test_select_questions_all(tmp_path):
+    files = [tmp_path / f"{i:04d}.yaml" for i in range(5)]
+    for f in files:
+        f.touch()
+    result = run_full_evals.select_questions(files, 1)
+    assert result == sorted(files)
+
+
+def test_select_questions_invalid():
+    with pytest.raises(ValueError):
+        run_full_evals.select_questions([], 0)


### PR DESCRIPTION
## Summary
- add `--sample` option to `run_full_evals.py`
- document sampling in README
- test new `select_questions` helper

## Testing
- `flake8 --exclude node_modules .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857bc948e9c832baf259342eb9b24c3