### PR TITLE
Improve question generation conflict handling

### DIFF
--- a/data/conflict_areas.yaml
+++ b/data/conflict_areas.yaml
@@ -1,0 +1,11 @@
+conflicts:
+  - board
+  - customers
+  - regulation
+  - ethics
+  - profitability
+  - costs
+  - growth
+  - shareholders
+  - competitors
+  - technology

--- a/data/questions/0126-Strategic_Thinking-Balancing_customer_demands-Customer_Satisfaction_vs._Profit_Maximization.yaml
+++ b/data/questions/0126-Strategic_Thinking-Balancing_customer_demands-Customer_Satisfaction_vs._Profit_Maximization.yaml
@@ -1,0 +1,24 @@
+topic: Strategic Thinking
+subtopic: Balancing customer demands
+conflict: customers
+title: Customer Satisfaction vs. Profit Maximization
+question: 'The marketing team is pushing for a price decrease to increase customer
+  satisfaction and loyalty, while the finance team emphasizes the need to maintain
+  or increase profit margins. As the CEO, how would you decide between prioritizing
+  customer satisfaction and profit maximization in this situation while ensuring long-term
+  business sustainability?
+
+  '
+rubric:
+- dimension: Clarity and decisiveness of decision
+  ideal: The CEO clearly articulates the reasoning behind their decision, weighing
+    the short-term benefits of customer satisfaction against the long-term effects
+    on profitability and sustainable growth.
+- dimension: Strategic alignment
+  ideal: The CEO demonstrates strategic alignment by explaining how the decision aligns
+    with the company's overall mission, vision, and values, considering both customer-centric
+    and financial perspectives.
+- dimension: Resource optimization
+  ideal: The CEO outlines a plan for resource allocation that balances the needs of
+    customers with the financial objectives of the company, showing an understanding
+    of the trade-offs involved.

--- a/data/questions/0127-Strategic_Thinking-Ethical_Dilemmas_in_Market_Entry-Balancing_Profits_and_Ethical_Considerations.yaml
+++ b/data/questions/0127-Strategic_Thinking-Ethical_Dilemmas_in_Market_Entry-Balancing_Profits_and_Ethical_Considerations.yaml
@@ -1,0 +1,24 @@
+topic: Strategic Thinking
+subtopic: Ethical Dilemmas in Market Entry
+conflict: ethics
+title: Balancing Profits and Ethical Considerations
+question: 'Your team has identified a lucrative market for expansion, but gaining
+  a foothold requires working closely with a local partner known for questionable
+  business practices. How would you approach the decision-making process to balance
+  the potential financial gains with the ethical implications of partnering with such
+  an entity?
+
+  '
+rubric:
+- dimension: Clarity and Decisiveness
+  ideal: The CEO clearly articulates the ethical considerations at play and decisively
+    chooses a course of action that aligns with the company's values and long-term
+    sustainability.
+- dimension: Strategic Thinking
+  ideal: The CEO demonstrates the ability to think critically about the potential
+    consequences of their decision on both the financial performance and ethical reputation
+    of the company.
+- dimension: Leadership and Ethics
+  ideal: The CEO effectively communicates the ethical considerations to stakeholders
+    and leads by example in upholding the company's values, even in the face of financial
+    temptations.

--- a/data/questions/0128-Strategic_Thinking-Market_entry_strategies-Timing_Expansion_with_Limited_Resources.yaml
+++ b/data/questions/0128-Strategic_Thinking-Market_entry_strategies-Timing_Expansion_with_Limited_Resources.yaml
@@ -1,0 +1,23 @@
+topic: Strategic Thinking
+subtopic: Market entry strategies
+conflict: growth
+title: Timing Expansion with Limited Resources
+question: 'Due to limited resources, the company can only pursue expansion into one
+  new market at a time. How would you prioritize the timing of market entries to ensure
+  sustainable growth while maximizing the potential for success? Consider the trade-offs
+  between entering a high-growth but competitive market early versus entering a less
+  competitive but slower-growing market later.
+
+  '
+rubric:
+- dimension: Clarity and Decisiveness
+  ideal: The CEO clearly articulates the rationale behind the chosen market entry
+    timing, considering both short-term and long-term growth potential. Decisiveness
+    is demonstrated in the choice made.
+- dimension: Strategic Thinking
+  ideal: The CEO shows a deep understanding of market dynamics and competently evaluates
+    the risks and opportunities associated with different market entry timings. The
+    decision is aligned with the company's overall growth strategy.
+- dimension: Resource Management
+  ideal: The CEO demonstrates an ability to effectively allocate resources to support
+    the chosen market entry timing, balancing the need for growth with financial constraints.

--- a/data/questions/0129-Strategic_Thinking-Competitive_analysis-Cost-Cutting_Measures.yaml
+++ b/data/questions/0129-Strategic_Thinking-Competitive_analysis-Cost-Cutting_Measures.yaml
@@ -1,0 +1,24 @@
+topic: Strategic Thinking
+subtopic: Competitive analysis
+conflict: costs
+title: Cost-Cutting Measures
+question: 'As a result of increased competition, we are facing pressure to reduce
+  costs. How would you approach making tough decisions about implementing cost-cutting
+  measures that may have a significant impact on the company''s operations and employee
+  morale, while also ensuring the long-term financial health and stability of the
+  organization?
+
+  '
+rubric:
+- dimension: Clarity and decisiveness
+  ideal: The CEO clearly outlines the rationale behind the cost-cutting measures,
+    communicates the potential impact on operations and morale, and decisively implements
+    the necessary changes.
+- dimension: Strategic thinking
+  ideal: The CEO demonstrates an understanding of how the cost-cutting measures align
+    with the overall financial strategy of the company and considers the long-term
+    implications of these decisions.
+- dimension: Communication
+  ideal: The CEO effectively communicates with stakeholders, including employees and
+    investors, to explain the reasoning behind the cost-cutting measures and the expected
+    outcomes.

--- a/data/questions/0130-Strategic_Thinking-Long-term_planning-Market_Expansion_Dilemma.yaml
+++ b/data/questions/0130-Strategic_Thinking-Long-term_planning-Market_Expansion_Dilemma.yaml
@@ -1,0 +1,24 @@
+topic: Strategic Thinking
+subtopic: Long-term planning
+conflict: competitors
+title: Market Expansion Dilemma
+question: 'Our main competitor just announced plans to expand into a new market that
+  we were considering entering next year. Should we accelerate our timeline and launch
+  before them to secure a first-mover advantage, or stick to our original plan to
+  ensure we are fully prepared? How would you approach this dilemma while considering
+  the potential risks and rewards of each option?
+
+  '
+rubric:
+- dimension: Clarity and decisiveness
+  ideal: The CEO clearly articulates the rationale behind their decision and confidently
+    defends their chosen course of action, taking into account both short-term and
+    long-term implications.
+- dimension: Strategic thinking
+  ideal: The CEO demonstrates a deep understanding of the competitive landscape, considering
+    not only the immediate threat from the competitor but also the overall impact
+    on our market positioning and growth potential.
+- dimension: Resource allocation
+  ideal: The CEO carefully evaluates the resources required for both scenarios and
+    makes a strategic decision on how best to allocate resources to maximize the chances
+    of success in the chosen approach.

--- a/data/questions/0131-Strategic_Thinking-Vision_articulation-Conflict_of_Interest.yaml
+++ b/data/questions/0131-Strategic_Thinking-Vision_articulation-Conflict_of_Interest.yaml
@@ -1,0 +1,24 @@
+topic: Strategic Thinking
+subtopic: Vision articulation
+conflict: ethics
+title: Conflict of Interest
+question: 'The company is considering a partnership with a vendor who has a history
+  of unethical practices. The partnership could significantly increase revenue and
+  market share, but it goes against the company''s commitment to ethics. How would
+  you navigate this conflict of interest while upholding the company''s core values
+  and making a decisive decision?
+
+  '
+rubric:
+- dimension: Clarity and decisiveness of decision
+  ideal: The CEO clearly identifies the conflict of interest, thoroughly analyzes
+    the potential consequences of both options, and ultimately makes a decisive decision
+    that aligns with the company's core values.
+- dimension: Ethical reasoning
+  ideal: The CEO demonstrates a deep understanding of ethical principles, weighs the
+    impact of the decision on all stakeholders, and chooses the option that upholds
+    integrity and trust.
+- dimension: Communication of decision
+  ideal: The CEO effectively communicates the decision-making process, rationale behind
+    the chosen course of action, and reinforces the importance of ethical decision-making
+    to all employees.

--- a/data/questions/0132-Operational_Excellence-Resource_optimization-Compliance_Cost_Dilemma.yaml
+++ b/data/questions/0132-Operational_Excellence-Resource_optimization-Compliance_Cost_Dilemma.yaml
@@ -1,0 +1,24 @@
+topic: Operational Excellence
+subtopic: Resource optimization
+conflict: regulation
+title: Compliance Cost Dilemma
+question: 'The company faces increasing pressure from regulatory bodies to comply
+  with new costly regulations aimed at environmental protection. However, allocating
+  a significant portion of the budget towards compliance may impact other critical
+  operational areas. How should the CEO navigate this situation to ensure both compliance
+  and financial sustainability?
+
+  '
+rubric:
+- dimension: Clarity and decisiveness
+  ideal: The CEO clearly outlines the potential impact of non-compliance and the consequences
+    of allocating resources away from compliance. The decision made demonstrates a
+    clear understanding of the trade-offs involved.
+- dimension: Strategic thinking
+  ideal: The CEO considers long-term implications of both compliance and resource
+    allocation decisions. The strategy aligns with the company's overall goals and
+    values.
+- dimension: Communication and transparency
+  ideal: The CEO communicates openly with stakeholders about the regulatory challenges
+    and the rationale behind the decisions made. Transparency is maintained throughout
+    the process.

--- a/data/questions/0133-Operational_Excellence-Process_improvement-Managing_Customer_Expectations.yaml
+++ b/data/questions/0133-Operational_Excellence-Process_improvement-Managing_Customer_Expectations.yaml
@@ -1,0 +1,21 @@
+topic: Operational Excellence
+subtopic: Process improvement
+conflict: customers
+title: Managing Customer Expectations
+question: 'Your customer service team is receiving complaints about product delivery
+  delays due to supply chain issues. On one hand, you have a commitment to delivering
+  a seamless customer experience. On the other hand, addressing the supply chain issue
+  could incur significant costs. How do you decide on the best course of action to
+  balance customer satisfaction with financial implications?
+
+  '
+rubric:
+- dimension: Clarity and decisiveness of decision
+  ideal: The CEO clearly articulates the rationale behind the decision, weighing the
+    pros and cons of each option before making a definitive choice.
+- dimension: Strategic thinking
+  ideal: The CEO demonstrates a strategic approach by considering the long-term impact
+    on customer loyalty and brand reputation, not just the immediate cost implications.
+- dimension: Communication and transparency
+  ideal: The CEO communicates the decision to both internal teams and customers transparently,
+    explaining the reasoning behind the choice and managing expectations effectively.

--- a/data/questions/0134-Operational_Excellence-Performance_metrics-Market_Expansion_Dilemma.yaml
+++ b/data/questions/0134-Operational_Excellence-Performance_metrics-Market_Expansion_Dilemma.yaml
@@ -1,0 +1,24 @@
+topic: Operational Excellence
+subtopic: Performance metrics
+conflict: competitors
+title: Market Expansion Dilemma
+question: 'Your top competitors are aggressively expanding into new markets, putting
+  pressure on your market share. With limited resources, do you prioritize defending
+  your current market position or invest in entering new markets to stay competitive?
+  How would you approach this dilemma while maintaining clarity and decisiveness in
+  your decision-making process?
+
+  '
+rubric:
+- dimension: Decision Clarity and Decisiveness
+  ideal: The CEO clearly articulates the rationale behind their chosen strategy, whether
+    it is to defend current market share or expand into new markets, and is decisive
+    in making the tough trade-offs necessary to execute the chosen approach.
+- dimension: Resource Allocation
+  ideal: The CEO demonstrates an understanding of resource constraints and explains
+    how resources will be allocated to support the chosen strategy, ensuring optimal
+    utilization and return on investment.
+- dimension: Competitor Analysis
+  ideal: The CEO shows a deep understanding of the competitive landscape, including
+    the strengths and weaknesses of key competitors, to inform their strategic decision-making
+    process.

--- a/data/questions/0135-Operational_Excellence-Efficiency_analysis-Legacy_Software_Migration.yaml
+++ b/data/questions/0135-Operational_Excellence-Efficiency_analysis-Legacy_Software_Migration.yaml
@@ -1,0 +1,24 @@
+topic: Operational Excellence
+subtopic: Efficiency analysis
+conflict: technology
+title: Legacy Software Migration
+question: 'The IT team has proposed migrating all legacy systems to a cloud-based
+  solution to improve efficiency and reduce maintenance costs. However, this will
+  require a significant upfront investment and potential disruptions to daily operations.
+  How would you decide whether to commit to the migration, considering the trade-offs
+  between short-term costs and long-term benefits?
+
+  '
+rubric:
+- dimension: Clarity and decisiveness
+  ideal: The CEO demonstrates a clear understanding of the potential risks and benefits
+    of the migration, makes a timely decision based on available information, and
+    communicates the rationale effectively to stakeholders.
+- dimension: Resource Management
+  ideal: The CEO considers the available resources, both financial and human, and
+    develops a plan to minimize disruptions during the migration process while ensuring
+    the long-term benefits justify the investment.
+- dimension: Strategic Vision
+  ideal: The CEO aligns the decision to migrate legacy systems with the company's
+    strategic goals and objectives, ensuring that the technology integration supports
+    overall business growth and efficiency.

--- a/data/questions/0136-Leadership_&_Communication-Team_motivation-Allocation_of_Profits.yaml
+++ b/data/questions/0136-Leadership_&_Communication-Team_motivation-Allocation_of_Profits.yaml
@@ -1,0 +1,22 @@
+topic: Leadership & Communication
+subtopic: Team motivation
+conflict: shareholders
+title: Allocation of Profits
+question: 'As the CEO, you are faced with the decision of how to allocate profits
+  between reinvesting in growth opportunities, paying out dividends to shareholders,
+  and strengthening the company''s financial position. How do you balance these competing
+  interests while also ensuring the long-term sustainability and value creation for
+  shareholders?
+
+  '
+rubric:
+- dimension: Clarity of decision
+  ideal: The CEO clearly articulates the rationale behind the chosen allocation strategy,
+    outlining the short-term impacts versus the long-term benefits for shareholders.
+- dimension: Decisiveness
+  ideal: The CEO makes a well-considered and timely decision on profit allocation,
+    taking into account all stakeholders' interests and potential risks.
+- dimension: Trade-off analysis
+  ideal: The CEO demonstrates a comprehensive understanding of the trade-offs involved
+    in each option and makes a strategic choice that maximizes shareholder value while
+    considering the company's future growth prospects.

--- a/data/questions/0137-Leadership_&_Communication-Stakeholder_management-Handling_Conflicting_Stakeholder_Interests.yaml
+++ b/data/questions/0137-Leadership_&_Communication-Stakeholder_management-Handling_Conflicting_Stakeholder_Interests.yaml
@@ -1,0 +1,23 @@
+topic: Leadership & Communication
+subtopic: Stakeholder management
+conflict: ethics
+title: Handling Conflicting Stakeholder Interests
+question: 'Your company has a contract with a supplier who is offering a kickback
+  in exchange for renewing a lucrative deal. On one hand, accepting the kickback could
+  greatly benefit the company financially, but it goes against your ethical principles
+  and could damage the company''s reputation if uncovered. How do you decide the best
+  course of action in this situation, considering the conflicting interests of the
+  supplier, shareholders, and company values?
+
+  '
+rubric:
+- dimension: Clarity and decisiveness
+  ideal: The CEO clearly articulates the ethical dilemma, weighs the potential consequences,
+    and makes a clear decision that aligns with the company's values.
+- dimension: Stakeholder management
+  ideal: The CEO effectively communicates the decision to stakeholders, manages expectations,
+    and provides a rationale for the chosen course of action.
+- dimension: Strategic decision-making
+  ideal: The CEO demonstrates a strategic approach by considering both the short-term
+    financial gains and long-term implications for the company's reputation and ethical
+    standing.

--- a/data/questions/0138-Leadership_&_Communication-Crisis_communication-Managing_Cost-Cutting_Measures.yaml
+++ b/data/questions/0138-Leadership_&_Communication-Crisis_communication-Managing_Cost-Cutting_Measures.yaml
@@ -1,0 +1,22 @@
+topic: Leadership & Communication
+subtopic: Crisis communication
+conflict: profitability
+title: Managing Cost-Cutting Measures
+question: "Your company is facing a significant financial downturn, and the board\
+  \ is pressuring you to implement cost-cutting measures that will directly impact\
+  \ employees and potentially lead to layoffs. How do you make a decisive decision\
+  \ balancing the company's financial health and profitability with the well-being\
+  \ and morale of your team? \n"
+rubric:
+- dimension: Clarity and decisiveness
+  ideal: The CEO clearly outlines the rationale behind the cost-cutting measures,
+    communicates the potential impact on employees, and makes a well-thought-out decision
+    promptly to address the financial challenges.
+- dimension: Employee morale
+  ideal: The CEO considers alternative solutions to layoffs, communicates openly with
+    employees about the situation, and implements support mechanisms to maintain team
+    morale during the challenging period.
+- dimension: Financial impact assessment
+  ideal: The CEO conducts a thorough analysis of the cost-cutting measures, evaluates
+    the short-term and long-term financial implications, and makes decisions that
+    prioritize sustainable profitability without compromising the company's values.

--- a/data/questions/0139-Leadership_&_Communication-Culture_building-Regulatory_Risk_Mitigation.yaml
+++ b/data/questions/0139-Leadership_&_Communication-Culture_building-Regulatory_Risk_Mitigation.yaml
@@ -1,0 +1,23 @@
+topic: Leadership & Communication
+subtopic: Culture building
+conflict: regulation
+title: Regulatory Risk Mitigation
+question: 'Your company is facing increased scrutiny and regulation from a government
+  agency, which threatens to stifle innovation and growth. How do you balance the
+  need for regulatory compliance while also fostering a culture of innovation and
+  pushing boundaries in the market?
+
+  '
+rubric:
+- dimension: Clarity and decisiveness of decision
+  ideal: The CEO clearly outlines a strategic plan for addressing regulatory concerns
+    while still promoting a culture of innovation, demonstrating a clear understanding
+    of the potential impact on the organization.
+- dimension: Stakeholder communication
+  ideal: The CEO communicates effectively with internal and external stakeholders,
+    providing transparency around regulatory challenges and the organization's approach
+    to compliance while encouraging open dialogue.
+- dimension: Adaptability
+  ideal: The CEO demonstrates flexibility in adapting to changing regulatory landscapes,
+    showing an ability to pivot strategies as needed to ensure both compliance and
+    continued innovation.

--- a/data/questions/0140-Financial_Acumen-Financial_modeling-Handling_Conflict_of_Interest.yaml
+++ b/data/questions/0140-Financial_Acumen-Financial_modeling-Handling_Conflict_of_Interest.yaml
@@ -1,0 +1,22 @@
+topic: Financial Acumen
+subtopic: Financial modeling
+conflict: ethics
+title: Handling Conflict of Interest
+question: 'As a CEO, you are faced with a situation where a close personal friend
+  is bidding for a major contract with your company. How would you navigate this conflict
+  of interest while ensuring fairness and transparency in the decision-making process?
+
+  '
+rubric:
+- dimension: Ethical Leadership
+  ideal: The CEO acknowledges the conflict of interest transparently, recuses themselves
+    from the decision-making process, and ensures that an unbiased individual or committee
+    handles the evaluation.
+- dimension: Stakeholder Trust
+  ideal: The CEO communicates openly with all stakeholders about the conflict of interest
+    and the steps taken to mitigate it, building trust and credibility with both internal
+    and external parties.
+- dimension: Business Integrity
+  ideal: The CEO upholds the company's values and code of conduct by prioritizing
+    the best interests of the company and its stakeholders over personal relationships,
+    demonstrating a commitment to ethical business practices.

--- a/data/questions/0141-Financial_Acumen-Investment_analysis-Prioritizing_Customer_Complaints.yaml
+++ b/data/questions/0141-Financial_Acumen-Investment_analysis-Prioritizing_Customer_Complaints.yaml
@@ -1,0 +1,24 @@
+topic: Financial Acumen
+subtopic: Investment analysis
+conflict: customers
+title: Prioritizing Customer Complaints
+question: 'As the CEO, you receive feedback from customers highlighting various issues
+  with your products and services. However, you have limited resources to address
+  all the complaints at once. How do you prioritize which customer complaints to address
+  first while balancing the need to retain customers and maintain a positive brand
+  reputation?
+
+  '
+rubric:
+- dimension: Clarity and decisiveness of decision
+  ideal: The CEO clearly explains their rationale for prioritizing certain customer
+    complaints over others, demonstrating an understanding of the potential impact
+    on customer satisfaction and brand reputation.
+- dimension: Strategic thinking
+  ideal: The CEO considers the long-term implications of addressing specific customer
+    complaints, focusing on those that align with the company's values and strategic
+    objectives.
+- dimension: Communication skills
+  ideal: The CEO effectively communicates with both internal teams and customers about
+    the prioritization process, managing expectations and engaging stakeholders in
+    the decision-making.

--- a/data/questions/0142-Financial_Acumen-Risk_assessment-Cost_Reduction_Strategy.yaml
+++ b/data/questions/0142-Financial_Acumen-Risk_assessment-Cost_Reduction_Strategy.yaml
@@ -1,0 +1,23 @@
+topic: Financial Acumen
+subtopic: Risk assessment
+conflict: profitability
+title: Cost Reduction Strategy
+question: 'The company is facing decreased profitability due to rising production
+  costs. As the CEO, you must decide between implementing layoffs to reduce expenses
+  or investing in efficiency improvements to decrease costs in the long term. How
+  do you plan to address this conflict to ensure the company''s financial health and
+  sustainability?
+
+  '
+rubric:
+- dimension: Clarity and decisiveness of decision
+  ideal: The CEO clearly justifies their decision with a well-thought-out strategy
+    that balances short-term sacrifices with long-term gains.
+- dimension: Financial impact analysis
+  ideal: The CEO evaluates the potential financial impact of both options, considering
+    not only immediate cost savings but also the long-term implications for profitability
+    and competitiveness.
+- dimension: Stakeholder communication
+  ideal: The CEO effectively communicates the decision-making process and rationale
+    to employees and stakeholders, emphasizing the company's commitment to financial
+    stability and growth.

--- a/data/questions/0143-Financial_Acumen-Budget_planning-Data_Protection_Policy_Implementation.yaml
+++ b/data/questions/0143-Financial_Acumen-Budget_planning-Data_Protection_Policy_Implementation.yaml
@@ -1,0 +1,20 @@
+topic: Financial Acumen
+subtopic: Budget planning
+conflict: regulation
+title: Data Protection Policy Implementation
+question: 'As the CEO, you are under pressure to implement a new data protection policy
+  to comply with the latest regulations. However, this will require a significant
+  investment in IT infrastructure and employee training. How do you prioritize resources
+  to ensure compliance while also maintaining financial stability?
+
+  '
+rubric:
+- dimension: Clarity and decisiveness
+  ideal: The CEO clearly articulates the rationale behind the resource allocation
+    decisions made for data protection policy implementation.
+- dimension: Strategic thinking
+  ideal: The CEO demonstrates a strategic approach by aligning the compliance efforts
+    with long-term business goals.
+- dimension: Communication skills
+  ideal: The CEO effectively communicates the importance of data protection compliance
+    to stakeholders and motivates employees to embrace the new policy.

--- a/data/questions/0144-Risk_&_Ethics-Regulatory_compliance-Expansion_Dilemma.yaml
+++ b/data/questions/0144-Risk_&_Ethics-Regulatory_compliance-Expansion_Dilemma.yaml
@@ -1,0 +1,19 @@
+topic: Risk & Ethics
+subtopic: Regulatory compliance
+conflict: profitability
+title: Expansion Dilemma
+question: "Your company has the opportunity to expand into a new market with high\
+  \ growth potential, but it requires a significant upfront investment that will impact\
+  \ short-term profitability. How do you decide whether to pursue this expansion considering\
+  \ the trade off between immediate profits and long-term growth? \n"
+rubric:
+- dimension: Clarity and decisiveness
+  ideal: The CEO clearly outlines the potential risks and rewards of the expansion
+    decision, along with a well-defined strategy for managing short-term profitability
+    while pursuing long-term growth.
+- dimension: Strategic thinking
+  ideal: The CEO demonstrates a deep understanding of the market dynamics, competition,
+    and internal capabilities, considering all factors in making the decision.
+- dimension: Resource management
+  ideal: The CEO shows a thoughtful approach to resource allocation, considering the
+    impact on profitability and the ability to sustain growth over time.

--- a/data/questions/0145-Risk_&_Ethics-Ethical_decision-making-Leveraging_AI_for_Customer_Data_Analysis.yaml
+++ b/data/questions/0145-Risk_&_Ethics-Ethical_decision-making-Leveraging_AI_for_Customer_Data_Analysis.yaml
@@ -1,0 +1,25 @@
+topic: Risk & Ethics
+subtopic: Ethical decision-making
+conflict: technology
+title: Leveraging AI for Customer Data Analysis
+question: 'As the CEO, you are faced with the decision of implementing AI technology
+  to analyze customer data for targeted marketing, which could significantly increase
+  sales. However, there are concerns about the ethical implications of potentially
+  invading customers'' privacy. How do you navigate this technology-driven dilemma
+  while ensuring ethical principles are upheld?
+
+  '
+rubric:
+- dimension: Clarity and decisiveness of decision
+  ideal: The CEO clearly communicates the rationale behind their decision and makes
+    a decisive choice that considers both the benefits of AI technology and the ethical
+    concerns regarding customer privacy.
+- dimension: Strategic alignment with company values
+  ideal: The CEO aligns the decision with the company's core values of ethical behavior
+    and customer trust, demonstrating a commitment to upholding ethical standards
+    even in the face of technological advancements.
+- dimension: Stakeholder communication
+  ideal: The CEO effectively communicates with stakeholders, including customers,
+    employees, and investors, about the decision-making process involving the use
+    of AI technology for customer data analysis, fostering transparency and trust
+    in the organization.

--- a/data/questions/0146-Risk_&_Ethics-Risk_mitigation-Evaluating_cost-benefit_analysis_for_risk_mitigation_measures.yaml
+++ b/data/questions/0146-Risk_&_Ethics-Risk_mitigation-Evaluating_cost-benefit_analysis_for_risk_mitigation_measures.yaml
@@ -1,0 +1,28 @@
+topic: Risk & Ethics
+subtopic: Risk mitigation
+conflict: profitability
+title: Evaluating cost-benefit analysis for risk mitigation measures
+question: 'You are faced with the decision of implementing costly risk mitigation
+  measures to protect against potential cyber attacks that could jeopardize company
+  data and reputation. However, these measures come with a significant upfront cost
+  that may impact short-term profitability. How would you approach evaluating the
+  cost-benefit analysis and make a decision that balances the need for risk mitigation
+  with the pressure to maintain profitability?
+
+  '
+rubric:
+- dimension: Clarity and decisiveness
+  ideal: The CEO clearly outlines the potential risks and benefits of implementing
+    the risk mitigation measures, demonstrating a thorough understanding of the trade-offs
+    involved. The decision-making process is logical and transparent, culminating
+    in a decisive action plan.
+- dimension: Strategic thinking
+  ideal: The CEO takes a strategic approach by considering the long-term implications
+    of both taking and not taking action to mitigate the identified risks. They demonstrate
+    the ability to prioritize objectives based on the company's overall strategic
+    goals.
+- dimension: Financial acumen
+  ideal: The CEO shows a strong understanding of the financial impact of the decision
+    on the company's profitability. They are able to weigh the short-term costs against
+    potential long-term benefits, taking into account the overall financial health
+    of the organization.

--- a/data/questions/0147-Risk_&_Ethics-Reputation_management-Pricing_Strategy_Dilemma.yaml
+++ b/data/questions/0147-Risk_&_Ethics-Reputation_management-Pricing_Strategy_Dilemma.yaml
@@ -1,0 +1,27 @@
+topic: Risk & Ethics
+subtopic: Reputation management
+conflict: competitors
+title: Pricing Strategy Dilemma
+question: 'Your main competitor just announced a significant price cut on their flagship
+  product, resulting in a surge of interest from customers. Do you match their price
+  to stay competitive and protect market share, even though it will significantly
+  impact profit margins, or do you maintain your current pricing strategy and risk
+  losing market share? How do you intend to address this pricing dilemma while maintaining
+  profitability and competitiveness in the market?
+
+  '
+rubric:
+- dimension: Clarity and Decisiveness
+  ideal: The CEO clearly explains their rationale for either matching or not matching
+    the competitor's price, demonstrating a deep understanding of the potential consequences
+    and risks associated with the decision.
+- dimension: Strategic Thinking
+  ideal: The CEO considers both short-term and long-term implications of the pricing
+    strategy on market positioning, customer perception, and overall profitability,
+    showcasing a strategic mindset in balancing immediate market pressures with long-term
+    sustainability.
+- dimension: Resource Allocation
+  ideal: The CEO outlines a plan for reallocating resources or cutting costs in other
+    areas to mitigate the impact on profit margins if choosing to match the competitor's
+    price, demonstrating a practical approach to managing limited resources in a competitive
+    environment.

--- a/data/questions/0148-Innovation_&_Growth-Product_innovation-Pivoting_Decisiveness.yaml
+++ b/data/questions/0148-Innovation_&_Growth-Product_innovation-Pivoting_Decisiveness.yaml
@@ -1,0 +1,23 @@
+topic: Innovation & Growth
+subtopic: Product innovation
+conflict: growth
+title: Pivoting Decisiveness
+question: 'The company is facing a critical juncture where continuing with the current
+  strategy may hinder growth potential, but pivoting to a new direction comes with
+  its own set of risks. How do you assess when it is appropriate to make a decisive
+  pivot in strategy to drive growth, considering the trade-offs and uncertainties
+  involved?
+
+  '
+rubric:
+- dimension: Strategic Vision
+  ideal: The CEO clearly articulates the rationale behind the pivot, aligning it with
+    the long-term goals of the company and addressing potential obstacles.
+- dimension: Risk Management
+  ideal: The CEO demonstrates a thorough risk assessment, including potential consequences
+    of both maintaining the status quo and implementing a pivot, and outlines mitigation
+    strategies.
+- dimension: Communication
+  ideal: The CEO communicates the pivot decisively and transparently to all stakeholders,
+    conveying confidence in the decision-making process and the ability to execute
+    the new strategy effectively.

--- a/data/questions/0149-Innovation_&_Growth-Technology_adoption-Expanding_into_New_Territory.yaml
+++ b/data/questions/0149-Innovation_&_Growth-Technology_adoption-Expanding_into_New_Territory.yaml
@@ -1,0 +1,24 @@
+topic: Innovation & Growth
+subtopic: Technology adoption
+conflict: competitors
+title: Expanding into New Territory
+question: 'Your team has identified a promising new market for expansion, but your
+  main competitor has also shown interest in entering the same territory. How will
+  you weigh the risks and rewards of moving forward with this expansion, considering
+  the competitive threat and potential benefits? How would you make a clear and decisive
+  decision in this situation?
+
+  '
+rubric:
+- dimension: Clarity and decisiveness
+  ideal: The CEO clearly articulates the strategic rationale for entering the new
+    market and demonstrates a decisive plan for implementation, taking both the competitive
+    landscape and growth potential into consideration.
+- dimension: Risk assessment
+  ideal: The CEO demonstrates a thorough analysis of the risks involved in entering
+    the new territory, including the competitive threats posed by existing players,
+    and proposes strategies to mitigate these risks.
+- dimension: Competitive strategy
+  ideal: The CEO outlines a comprehensive competitive strategy for outmaneuvering
+    the competitor in the new market, showcasing their ability to adapt and respond
+    to competitive threats effectively.

--- a/data/questions/0150-Innovation_&_Growth-Growth_strategy-Evaluating_Cost_Cutting_Measures.yaml
+++ b/data/questions/0150-Innovation_&_Growth-Growth_strategy-Evaluating_Cost_Cutting_Measures.yaml
@@ -1,0 +1,18 @@
+topic: Innovation & Growth
+subtopic: Growth strategy
+conflict: profitability
+title: Evaluating Cost Cutting Measures
+question: "The company is facing pressure to improve profitability, but cutting costs\
+  \ too deeply could impact the quality of our products and services. How will you\
+  \ balance the need for cost reduction with maintaining the value proposition for\
+  \ our customers? \n"
+rubric:
+- dimension: Clarity and decisiveness
+  ideal: The CEO clearly explains the rationale behind the cost-cutting measures and
+    demonstrates a decisive plan of action.
+- dimension: Strategic thinking
+  ideal: The CEO considers the long-term implications of the cost reduction decisions
+    and how they align with the overall business strategy.
+- dimension: Communication skills
+  ideal: The CEO effectively communicates with stakeholders, including employees and
+    customers, about the cost-cutting measures and addresses concerns proactively.

--- a/data/questions/0151-Innovation_&_Growth-M&A_evaluation-Post-merger_Leadership_Alignment.yaml
+++ b/data/questions/0151-Innovation_&_Growth-M&A_evaluation-Post-merger_Leadership_Alignment.yaml
@@ -1,0 +1,22 @@
+topic: Innovation & Growth
+subtopic: M&A evaluation
+conflict: board
+title: Post-merger Leadership Alignment
+question: 'After completing an acquisition, the board is split on the leadership structure
+  for the new combined entity. Some members support maintaining separate leadership
+  teams to preserve existing company cultures, while others advocate for a unified
+  structure for efficiency. How would you navigate this conflicting advice and make
+  a clear decision on the leadership alignment post-merger?
+
+  '
+rubric:
+- dimension: Clarity and decisiveness
+  ideal: The CEO clearly articulates the rationale behind their decision on the leadership
+    alignment and how it aligns with the overall strategic goals of the acquisition.
+- dimension: Alignment with company strategy
+  ideal: The decision on leadership structure demonstrates a clear understanding of
+    how it will impact the integration process and contribute to achieving synergies
+    and growth objectives.
+- dimension: Stakeholder management
+  ideal: The CEO communicates the decision effectively to the board, addressing concerns
+    and ensuring buy-in from key stakeholders to drive successful post-merger integration.

--- a/templates/question_gen_prompt.txt
+++ b/templates/question_gen_prompt.txt
@@ -1,14 +1,21 @@
 You are generating new questions for the CEO Bench evaluation.
 Each question should focus on the given topic and subtopic.
+The scenario must reflect messy executive realities with competing objectives,
+limited resources and trade offs.
+Include tension around the following area of conflict: {conflict}.
+Describe a very specific situation and write the question in two to three
+sentences. Add a `conflict` field with the same value.
+One rubric dimension must evaluate the clarity and decisiveness of the CEO's decision.
 Avoid repeating any of the existing titles listed below.
 Return YAML in the following structure:
 
 ```
 topic: {topic}
 subtopic: {subtopic}
+conflict: {conflict}
 title: <short title>
 question: |
-  <one to two sentence question>
+  <two to three sentence question>
 rubric:
   - dimension: <dimension 1>
     ideal: <ideal answer description>

--- a/templates/question_prompt.txt
+++ b/templates/question_prompt.txt
@@ -1,4 +1,4 @@
-You are taking the CEO Bench evaluation. Answer the following question as best you can.
+You are taking the CEO Bench evaluation. Provide a decisive answer as the CEO, stating your chosen course of action and why.
 
 Question:
 {question}

--- a/tests/test_generate_questions.py
+++ b/tests/test_generate_questions.py
@@ -3,10 +3,8 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from scripts.generate_questions import (  # noqa: E402
-    build_filename,
-    create_question,
-)
+from scripts.generate_questions import build_filename  # noqa: E402
+import scripts.question_utils as q_utils  # noqa: E402
 
 
 def test_build_filename_structure():
@@ -22,7 +20,22 @@ def test_build_filename_structure():
 
 
 def test_create_question_contains_fields():
-    q = create_question("Topic", "Sub")
+    q = q_utils.create_question("Topic", "Sub", "board")
     assert q["topic"] == "Topic"
     assert q["subtopic"] == "Sub"
+    assert q["conflict"] == "board"
     assert isinstance(q.get("rubric"), list)
+
+
+def test_create_question_llm_defaults(monkeypatch):
+    def fake_call_llm(prompt: str, model: str) -> str:
+        return "title: Example\nquestion: Example?\n"
+
+    monkeypatch.setattr(q_utils, "call_llm", fake_call_llm)
+
+    data = q_utils.create_question_llm(
+        "Topic", "Subtopic", [], "model", q_utils.DEFAULT_TEMPLATE
+    )
+    assert data["topic"] == "Topic"
+    assert data["subtopic"] == "Subtopic"
+    assert "conflict" in data


### PR DESCRIPTION
## Summary
- enforce topic, subtopic, and conflict when creating questions with LLM
- add tests for create_question_llm defaults
- regenerate one new question for each subtopic

## Testing
- `flake8 --exclude node_modules .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857ab016ccc832b9fdeed257b7ef038