### PR TITLE
Sort leaderboard rows and warn on missing names

### DIFF
--- a/scripts/aggregate_results.py
+++ b/scripts/aggregate_results.py
@@ -71,7 +71,13 @@ def aggregate(records, topics, model_names=None):
         by_topic[model][topic].append(float(total))
 
     rows = []
-    for model, vals in overall.items():
+    for model in sorted(overall):
+        vals = overall[model]
+        if model not in model_names:
+            print(
+                f"Notice: model name for '{model}' not found in {MODEL_NAMES_FILE}. "
+                "Using model id. Add the name to the yaml file and run aggregate_results.py again."
+            )
         row = {
             "model": model,
             "model_name": model_names.get(model, model),

--- a/tests/test_aggregate_results.py
+++ b/tests/test_aggregate_results.py
@@ -23,7 +23,18 @@ def test_aggregate_computes_averages():
     assert data["A"]["model_name"] == "Model A"
 
 
-def test_model_name_fallback():
+def test_model_name_fallback(capsys):
     records = [{"model": "X", "total": 3.0, "topic": "T"}]
     rows = aggregate(records, ["T"], {})
+    captured = capsys.readouterr()
     assert rows[0]["model_name"] == "X"
+    assert "Add the name to the yaml" in captured.out
+
+
+def test_rows_sorted_by_model_id():
+    records = [
+        {"model": "B", "total": 2.0, "topic": "T"},
+        {"model": "A", "total": 1.0, "topic": "T"},
+    ]
+    rows = aggregate(records, ["T"], {"A": "A", "B": "B"})
+    assert [r["model"] for r in rows] == ["A", "B"]


### PR DESCRIPTION
## Summary
- sort the aggregated leaderboard rows by model id
- print a notice when falling back to model id due to missing entry
- update tests for sorting and warning output

## Testing
- `pytest -q`
- `python scripts/aggregate_results.py`

------
https://chatgpt.com/codex/tasks/task_e_6858102df164832bbca42f28c915c763